### PR TITLE
Add support for converting multiple instances

### DIFF
--- a/autospotting.go
+++ b/autospotting.go
@@ -45,7 +45,9 @@ func run() {
 		"bidding_policy=%s "+
 		"tag_filters=%s "+
 		"tag_filter_mode=%s "+
-		"spot_product_description=%v",
+		"spot_product_description=%v "+
+		"max_spot_launch_number=%d "+
+		"max_spot_launch_percentage=%.1f\n",
 		conf.Regions,
 		conf.MinOnDemandNumber,
 		conf.MinOnDemandPercentage,
@@ -56,7 +58,10 @@ func run() {
 		conf.BiddingPolicy,
 		conf.FilterByTags,
 		conf.TagFilteringMode,
-		conf.SpotProductDescription)
+		conf.SpotProductDescription,
+		conf.MaxSpotLaunchNumber,
+		conf.MaxSpotLaunchPercentage,
+	)
 
 	autospotting.Run(conf.Config)
 	log.Println("Execution completed, nothing left to do")
@@ -116,6 +121,12 @@ func (c *cfgData) parseCommandLineFlags() {
 		"\n\tIf specified, the spot instances will _never_ be of these types.\n"+
 			"\tAccepts a list of comma or whitespace separated instance types (supports globs).\n"+
 			"\tExample: ./autospotting -disallowed_instance_types 't2.*,c4.xlarge'\n")
+	flag.Int64Var(&c.MaxSpotLaunchNumber, "max_spot_launch_number", autospotting.DefaultMaxLaunchNumber,
+		"\n\tMaximum number of instances that will be converted to Spot Instances per invocation.\n"+
+			"\tSet this value to 0 to use max_spot_launch_percentage instead.\n")
+	flag.Float64Var(&c.MaxSpotLaunchPercentage, "max_spot_launch_percentage", 0.0,
+		"\n\tMaximum percentage of instances that will be converted to Spot Instances per invocation.\n"+
+			"\tOnly used if max_spot_launch_number is not declared\n")
 	flag.Int64Var(&c.MinOnDemandNumber, "min_on_demand_number", autospotting.DefaultMinOnDemandValue,
 		"\n\tNumber of on-demand nodes to be kept running in each of the groups.\n\t"+
 			"Can be overridden on a per-group basis using the tag "+autospotting.OnDemandNumberLong+".\n")

--- a/cloudformation/stacks/AutoSpotting/template.yaml
+++ b/cloudformation/stacks/AutoSpotting/template.yaml
@@ -74,6 +74,19 @@
       Default: "7"
       Description: "Number of days to keep the Lambda function logs in CloudWatch."
       Type: "Number"
+    MaxSpotLaunchNumber:
+      Default: "1"
+      Description: >
+        "Maximum number of instances that will be converted to Spot Instances
+        per invocation. Set this value to 0 to use MaxSpotLaunchPercentage
+        instead"
+      Type: "Number"
+    MaxSpotLaunchPercentage:
+      Default: "0.0"
+      Description: >
+        "Maximum percentage of instances that will be converted to Spot
+        Instances per invocation."
+      Type: "Number"
     MinOnDemandNumber:
       Default: "0"
       Description: >
@@ -171,6 +184,10 @@
               Ref: "BiddingPolicy"
             DISALLOWED_INSTANCE_TYPES:
               Ref: "DisallowedInstanceTypes"
+            MAX_SPOT_LAUNCH_NUMBER:
+              Ref: "MaxSpotLaunchNumber"
+            MAX_SPOT_LAUNCH_PERCENTAGE:
+              Ref: "MaxSpotLaunchPercentage"
             MIN_ON_DEMAND_NUMBER:
               Ref: "MinOnDemandNumber"
             MIN_ON_DEMAND_PERCENTAGE:

--- a/core/config.go
+++ b/core/config.go
@@ -21,6 +21,9 @@ type Config struct {
 	// The region where the Lambda function is deployed
 	MainRegion string
 
+	MaxSpotLaunchPercentage float64
+	MaxSpotLaunchNumber     int64
+
 	MinOnDemandNumber         int64
 	MinOnDemandPercentage     float64
 	Regions                   string

--- a/core/util.go
+++ b/core/util.go
@@ -1,0 +1,8 @@
+package autospotting
+
+func minInt(a, b int) int {
+	if b < a {
+		return b
+	}
+	return a
+}

--- a/terraform/autospotting/lambda.tf
+++ b/terraform/autospotting/lambda.tf
@@ -14,6 +14,8 @@ module "aws_lambda_function" {
 
   autospotting_allowed_instance_types       = "${var.autospotting_allowed_instance_types}"
   autospotting_disallowed_instance_types    = "${var.autospotting_disallowed_instance_types}"
+  autospotting_max_spot_launch_number       = "${var.autospotting_max_spot_launch_number}"
+  autospotting_max_spot_launch_percentage   = "${var.autospotting_min_on_demand_percentage}"
   autospotting_min_on_demand_number         = "${var.autospotting_min_on_demand_number}"
   autospotting_min_on_demand_percentage     = "${var.autospotting_min_on_demand_percentage}"
   autospotting_on_demand_price_multiplier   = "${var.autospotting_on_demand_price_multiplier}"

--- a/terraform/autospotting/lambda/main.tf
+++ b/terraform/autospotting/lambda/main.tf
@@ -15,6 +15,8 @@ resource "aws_lambda_function" "autospotting" {
     variables = {
       ALLOWED_INSTANCE_TYPES       = "${var.autospotting_allowed_instance_types}"
       DISALLOWED_INSTANCE_TYPES    = "${var.autospotting_disallowed_instance_types}"
+      MAX_SPOT_LAUNCH_NUMBER       = "${var.autospotting_max_spot_launch_number}"
+      MAX_SPOT_LAUNCH_PERCENTAGE   = "${var.autospotting_max_spot_launch_percentage}"
       MIN_ON_DEMAND_NUMBER         = "${var.autospotting_min_on_demand_number}"
       MIN_ON_DEMAND_PERCENTAGE     = "${var.autospotting_min_on_demand_percentage}"
       ON_DEMAND_PRICE_MULTIPLIER   = "${var.autospotting_on_demand_price_multiplier}"
@@ -45,6 +47,8 @@ resource "aws_lambda_function" "autospotting_from_s3" {
     variables = {
       ALLOWED_INSTANCE_TYPES       = "${var.autospotting_allowed_instance_types}"
       DISALLOWED_INSTANCE_TYPES    = "${var.autospotting_disallowed_instance_types}"
+      MAX_SPOT_LAUNCH_NUMBER       = "${var.autospotting_max_spot_launch_number}"
+      MAX_SPOT_LAUNCH_PERCENTAGE   = "${var.autospotting_max_spot_launch_percentage}"
       MIN_ON_DEMAND_NUMBER         = "${var.autospotting_min_on_demand_number}"
       MIN_ON_DEMAND_PERCENTAGE     = "${var.autospotting_min_on_demand_percentage}"
       ON_DEMAND_PRICE_MULTIPLIER   = "${var.autospotting_on_demand_price_multiplier}"

--- a/terraform/autospotting/lambda/variables.tf
+++ b/terraform/autospotting/lambda/variables.tf
@@ -17,6 +17,9 @@ variable "lambda_memory_size" {}
 
 variable "autospotting_allowed_instance_types" {}
 variable "autospotting_disallowed_instance_types" {}
+variable "autospotting_max_spot_launch_number" {}
+variable "autospotting_max_spot_launch_percentage" {}
+
 variable "autospotting_min_on_demand_number" {}
 variable "autospotting_min_on_demand_percentage" {}
 variable "autospotting_on_demand_price_multiplier" {}

--- a/terraform/autospotting/variables.tf
+++ b/terraform/autospotting/variables.tf
@@ -24,6 +24,23 @@ EOF
   default = ""
 }
 
+variable "autospotting_max_spot_launch_number" {
+  description = <<EOF
+  Maximum number of instances that will be converted to Spot Instances per invocation.
+  Set this value to 0 to use autospotting_max_spot_launch_percentage instead.
+  EOF
+
+  default = "1"
+}
+
+variable "autospotting_max_spot_launch_percentage" {
+  description = <<EOF
+  Maximum percentage of instances that will be converted to Spot Instances per invocation.
+  EOF
+
+  default = "0"
+}
+
 variable "autospotting_min_on_demand_number" {
   description = "Minimum on-demand instances to keep in absolute value"
 }


### PR DESCRIPTION
Add support for converting launching multiple Spot Instances per
autospotting invocation.  The maximum number of instances to be launched
per invocation is adjustable by two new configuration parameters,
`max_spot_launch_number` and `max_spot_launch_percentage`.  Support for
Terraform and CloudFormation is included.

Improved efficiency by attaching all qualified Spot Instances that have
not yet been attached at each invocation.  Previously, only one instance
would be attached per invocation.

Fixes #284