### PR TITLE
Add support for environments using Launch Templates

### DIFF
--- a/core/instance.go
+++ b/core/instance.go
@@ -534,16 +534,13 @@ func (i *instance) createRunInstancesInput(instanceType string, price float64) *
 		TagSpecifications: i.generateTagsList(),
 	}
 
-	if i.IamInstanceProfile != nil {
-		retval.IamInstanceProfile = &ec2.IamInstanceProfileSpecification{
-			Arn: i.IamInstanceProfile.Arn,
-		}
-	}
-
 	if i.asg.LaunchTemplate != nil {
 		retval.LaunchTemplate = &ec2.LaunchTemplateSpecification{
-			LaunchTemplateId:   i.asg.LaunchTemplate.LaunchTemplateId,
-			LaunchTemplateName: i.asg.LaunchTemplate.LaunchTemplateName,
+			LaunchTemplateId: i.asg.LaunchTemplate.LaunchTemplateId,
+		}
+	} else if i.IamInstanceProfile != nil {
+		retval.IamInstanceProfile = &ec2.IamInstanceProfileSpecification{
+			Arn: i.IamInstanceProfile.Arn,
 		}
 	}
 
@@ -587,10 +584,6 @@ func (i *instance) generateTagsList() []*ec2.TagSpecification {
 		ResourceType: aws.String("instance"),
 		Tags: []*ec2.Tag{
 			{
-				Key:   aws.String("LaunchConfigurationName"),
-				Value: i.asg.LaunchConfigurationName,
-			},
-			{
 				Key:   aws.String("launched-by-autospotting"),
 				Value: aws.String("true"),
 			},
@@ -599,6 +592,18 @@ func (i *instance) generateTagsList() []*ec2.TagSpecification {
 				Value: aws.String(i.asg.name),
 			},
 		},
+	}
+
+	if i.asg.LaunchTemplate != nil {
+		tags.Tags = append(tags.Tags, &ec2.Tag{
+			Key:   aws.String("LaunchTemplateName"),
+			Value: i.asg.LaunchTemplate.LaunchTemplateName,
+		})
+	} else if i.asg.LaunchConfigurationName != nil {
+		tags.Tags = append(tags.Tags, &ec2.Tag{
+			Key:   aws.String("LaunchConfigurationName"),
+			Value: i.asg.LaunchConfigurationName,
+		})
 	}
 
 	for _, tag := range i.Tags {

--- a/core/instance.go
+++ b/core/instance.go
@@ -537,8 +537,11 @@ func (i *instance) createRunInstancesInput(instanceType string, price float64) *
 	if i.asg.LaunchTemplate != nil {
 		retval.LaunchTemplate = &ec2.LaunchTemplateSpecification{
 			LaunchTemplateId: i.asg.LaunchTemplate.LaunchTemplateId,
+			Version:          i.asg.LaunchTemplate.Version,
 		}
-	} else if i.IamInstanceProfile != nil {
+	}
+
+	if i.IamInstanceProfile != nil {
 		retval.IamInstanceProfile = &ec2.IamInstanceProfileSpecification{
 			Arn: i.IamInstanceProfile.Arn,
 		}
@@ -596,8 +599,12 @@ func (i *instance) generateTagsList() []*ec2.TagSpecification {
 
 	if i.asg.LaunchTemplate != nil {
 		tags.Tags = append(tags.Tags, &ec2.Tag{
-			Key:   aws.String("LaunchTemplateName"),
-			Value: i.asg.LaunchTemplate.LaunchTemplateName,
+			Key:   aws.String("LaunchTemplateID"),
+			Value: i.asg.LaunchTemplate.LaunchTemplateId,
+		})
+		tags.Tags = append(tags.Tags, &ec2.Tag{
+			Key:   aws.String("LaunchTemplateVersion"),
+			Value: i.asg.LaunchTemplate.Version,
 		})
 	} else if i.asg.LaunchConfigurationName != nil {
 		tags.Tags = append(tags.Tags, &ec2.Tag{


### PR DESCRIPTION
* Fixes https://github.com/cristim/autospotting/issues/285
* Add appropriate EC2 tag depending on if we are using launch config or
  template

# Issue Type

- Bugfix Pull Request

## Summary

Fixes https://github.com/cristim/autospotting/issues/285, which would prevent usage of launch templates, due to specifying both the ID and name at the same time.

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [x] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [x] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [x] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [x] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
