### PR TITLE
Detach instance when spot termination notification is received

### DIFF
--- a/autospotting.go
+++ b/autospotting.go
@@ -99,8 +99,8 @@ func Handler(ctx context.Context, event events.CloudWatchEvent) {
 	}
 
 	if instanceID != nil {
-		spotTermination := autospotting.SpotTermination{}
-		spotTermination.DetachInstance(instanceID, event.Region)
+		spotTermination := autospotting.NewSpotTermination(event.Region)
+		spotTermination.DetachInstance(instanceID)
 	} else {
 		run()
 	}

--- a/autospotting.go
+++ b/autospotting.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -89,8 +90,20 @@ func init() {
 }
 
 // Handler implements the AWS Lambda handler
-func Handler(request events.APIGatewayProxyRequest) {
-	run()
+func Handler(ctx context.Context, event events.CloudWatchEvent) {
+
+	instanceID, err := autospotting.GetInstanceIDDueForTermination(event)
+
+	if err != nil {
+		return
+	}
+
+	if instanceID != nil {
+		spotTermination := autospotting.SpotTermination{}
+		spotTermination.DetachInstance(instanceID, event.Region)
+	} else {
+		run()
+	}
 }
 
 // Configuration handling

--- a/cloudformation/stacks/AutoSpotting/template.yaml
+++ b/cloudformation/stacks/AutoSpotting/template.yaml
@@ -220,6 +220,7 @@
               Action:
                 - "autoscaling:AttachInstances"
                 - "autoscaling:DescribeAutoScalingGroups"
+                - "autoscaling:DescribeAutoScalingInstances"
                 - "autoscaling:DescribeLaunchConfigurations"
                 - "autoscaling:DescribeTags"
                 - "autoscaling:DetachInstances"
@@ -281,4 +282,23 @@
                 - "Arn"
             Id: "AutoSpottingEventGenerator"
       Type: "AWS::Events::Rule"
-
+    SpotTerminationEventRule:
+      Properties: 
+        Description: "EventRule for launching AutoSpotting Lambda function when a spot instance termination notification is triggered"
+        EventPattern: {
+          "source": [
+            "aws.ec2"
+          ],
+          "detail-type": [
+            "EC2 Spot Instance Interruption Warning"
+          ]
+        }
+        State: "ENABLED"
+        Targets:
+          -
+            Arn:
+              Fn::GetAtt:
+                - "LambdaFunction"
+                - "Arn"
+            Id: "AutoSpottingTerminationEventGenerator"    
+      Type: AWS::Events::Rule

--- a/cloudformation/stacks/AutoSpotting/template.yaml
+++ b/cloudformation/stacks/AutoSpotting/template.yaml
@@ -226,6 +226,9 @@
                 - "autoscaling:DetachInstances"
                 - "autoscaling:TerminateInstanceInAutoScalingGroup"
                 - "autoscaling:UpdateAutoScalingGroup"
+                - "cloudformation:CreateStack"
+                - "cloudformation:DeleteStack"
+                - "cloudformation:Describe*"
                 - "ec2:CreateTags"
                 - "ec2:DescribeInstanceAttribute"
                 - "ec2:DescribeInstances"
@@ -233,11 +236,21 @@
                 - "ec2:DescribeSpotPriceHistory"
                 - "ec2:RunInstances"
                 - "ec2:TerminateInstances"
+                - "events:PutRule"
+                - "events:PutTargets"
+                - "events:DeleteRule"
+                - "events:DescribeRule"
+                - "events:RemoveTargets"
                 - "iam:CreateServiceLinkedRole"
                 - "iam:PassRole"
                 - "logs:CreateLogGroup"
                 - "logs:CreateLogStream"
                 - "logs:PutLogEvents"
+                - "sns:CreateTopic"
+                - "sns:DeleteTopic"
+                - "sns:GetTopicAttributes"
+                - "sns:SetTopicAttributes"
+                - "sns:Subscribe"
               Effect: "Allow"
               Resource: "*"
         PolicyName: "LambdaPolicy"
@@ -282,23 +295,128 @@
                 - "Arn"
             Id: "AutoSpottingEventGenerator"
       Type: "AWS::Events::Rule"
-    SpotTerminationEventRule:
+    TerminationEventRuleFunction:
+      Type: AWS::Lambda::Function
+      Properties:
+        Description: "Creates, deletes EventRule for launching AutoSpotting Lambda function on spot instance termination notification"
+        Handler: "index.handler"
+        Runtime: "python3.6"
+        Timeout: "300"
+        Role:
+          Fn::GetAtt:
+            - "LambdaExecutionRole"
+            - "Arn"
+        Code:
+          ZipFile: |
+            import boto3
+            import botocore
+            import cfnresponse
+            import json
+            import sys
+            import traceback
+
+            stack_name = 'AutoSpotTerminationEvent'
+
+            def get_cf_template(lambda_arn):
+              return {
+                "AWSTemplateFormatVersion" : "2010-09-09",
+                "Description" : "Notification stack for spot termination event",
+                "Resources": {
+                  "AutoSpotTerminationNotificationTopic": {
+                    "Type" : "AWS::SNS::Topic",
+                    "Properties" : {
+                      "DisplayName" : "autospotting-termination-notification-topic",
+                      "Subscription": [
+                        {
+                          "Endpoint": lambda_arn,
+                          "Protocol": "lambda"
+                        }
+                      ]                  
+                    }
+                  },
+                  "AutoSpotTeminationEventRule": {
+                    "Type" : "AWS::Events::Rule",
+                    "Properties" : {
+                      "Description" : "This rule is triggered 2 minutes before AWS terminates a spot instance",
+                      "EventPattern" : {
+                        "detail-type": ["EC2 Spot Instance Interruption Warning"],
+                        "source": ["aws.ec2"]
+                      },
+                      "State" : "ENABLED",
+                      "Targets" : [ 
+                        {
+                          "Id": "AutoSpottingTerminationEventGenerator",
+                          "Arn": { "Ref":  "AutoSpotTerminationNotificationTopic" }
+                        }  
+                      ]
+                    }
+                  }
+                }
+              }
+
+            def handle_delete(event):
+              ec2 = boto3.client('ec2')
+              wait_for_deletion = False
+              for region in ec2.describe_regions()['Regions']:
+                client = boto3.client('cloudformation', region['RegionName'])
+                #try except to make sure stack exists before deletion
+                try:
+                  client.describe_stacks(
+                    StackName=stack_name
+                  )
+                  client.delete_stack(
+                    StackName=stack_name
+                  )
+                  wait_for_deletion = True
+                except botocore.exceptions.ClientError:  
+                  pass
+
+              #Wait only for last otherwise stack deletion will take forever  
+              if wait_for_deletion == True:
+                waiter = client.get_waiter('stack_delete_complete')
+                waiter.wait(
+                  StackName=stack_name
+                ) 
+            
+            def handle_create(event):
+              ec2 = boto3.client('ec2')
+              lambda_arn = event['ResourceProperties']['LambdaARN']
+
+              for region in ec2.describe_regions()['Regions']:
+                client = boto3.client('cloudformation', region['RegionName'])
+                #try except to make sure stack does not exist before creation
+                try:
+                  client.describe_stacks(
+                    StackName=stack_name
+                  )
+                except botocore.exceptions.ClientError:  
+                  client.create_stack(
+                    StackName=stack_name,
+                    TemplateBody=json.dumps(get_cf_template(lambda_arn))
+                  )
+
+            def handler(event, context):
+              try:
+                if event['RequestType'] == 'Delete':
+                  handle_delete(event)
+                
+                if event['RequestType'] == 'Create':
+                  handle_create(event)
+                cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+              except:
+                traceback.print_exc()
+                print("Unexpected error:", sys.exc_info()[0])
+                cfnresponse.send(event, context, cfnresponse.FAILED, {})
+
+    TerminationEventRuleCallout:        
+      Type: "Custom::LambdaCallout"
       Properties: 
-        Description: "EventRule for launching AutoSpotting Lambda function when a spot instance termination notification is triggered"
-        EventPattern: {
-          "source": [
-            "aws.ec2"
-          ],
-          "detail-type": [
-            "EC2 Spot Instance Interruption Warning"
-          ]
-        }
-        State: "ENABLED"
-        Targets:
-          -
-            Arn:
-              Fn::GetAtt:
-                - "LambdaFunction"
-                - "Arn"
-            Id: "AutoSpottingTerminationEventGenerator"    
-      Type: AWS::Events::Rule
+        ServiceToken:
+          Fn::GetAtt:
+            - "TerminationEventRuleFunction"
+            - "Arn"
+        LambdaARN: 
+          Fn::GetAtt:
+            - "LambdaFunction"
+            - "Arn"
+      DependsOn: LambdaPolicy      

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -134,7 +134,8 @@ type mockASG struct {
 	dasgo *autoscaling.DescribeAutoScalingGroupsOutput
 
 	// Describe AutoScalingInstances
-	dasio *autoscaling.DescribeAutoScalingInstancesOutput
+	dasio   *autoscaling.DescribeAutoScalingInstancesOutput
+	dasierr error
 }
 
 func (m mockASG) DetachInstances(*autoscaling.DetachInstancesInput) (*autoscaling.DetachInstancesOutput, error) {
@@ -168,5 +169,5 @@ func (m mockASG) DescribeAutoScalingGroupsPages(input *autoscaling.DescribeAutoS
 }
 
 func (m mockASG) DescribeAutoScalingInstances(inout *autoscaling.DescribeAutoScalingInstancesInput) (*autoscaling.DescribeAutoScalingInstancesOutput, error) {
-	return m.dasio, nil
+	return m.dasio, m.dasierr
 }

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -132,6 +132,9 @@ type mockASG struct {
 
 	// Describe AutoScaling Group
 	dasgo *autoscaling.DescribeAutoScalingGroupsOutput
+
+	// Describe AutoScalingInstances
+	dasio *autoscaling.DescribeAutoScalingInstancesOutput
 }
 
 func (m mockASG) DetachInstances(*autoscaling.DetachInstancesInput) (*autoscaling.DetachInstancesOutput, error) {
@@ -162,4 +165,8 @@ func (m mockASG) DescribeTagsPages(input *autoscaling.DescribeTagsInput, functio
 func (m mockASG) DescribeAutoScalingGroupsPages(input *autoscaling.DescribeAutoScalingGroupsInput, function func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool) error {
 	function(m.dasgo, true)
 	return nil
+}
+
+func (m mockASG) DescribeAutoScalingInstances(inout *autoscaling.DescribeAutoScalingInstancesInput) (*autoscaling.DescribeAutoScalingInstancesOutput, error) {
+	return m.dasio, nil
 }

--- a/core/spot_termination.go
+++ b/core/spot_termination.go
@@ -1,0 +1,92 @@
+package autospotting
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
+)
+
+//SpotTermination is used to detach an instance, used when a spot instance is due for termination
+type SpotTermination struct {
+	asSvc autoscalingiface.AutoScalingAPI
+}
+
+//InstanceData represents JSON structure of the Detail property of CloudWatch event when a spot instance is terminated
+//Reference = https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html#spot-instance-termination-notices
+type instanceData struct {
+	InstanceID     string `json:"instance-id"`
+	InstanceAction string `json:"instance-action"`
+}
+
+//GetInstanceIDDueForTermination checks if the given CloudWatch event data is triggered from a spot termination
+//If it is a termination event for a spot instance, it returns the instance id present in the event data
+func GetInstanceIDDueForTermination(event events.CloudWatchEvent) (*string, error) {
+
+	var detailData instanceData
+	if err := json.Unmarshal(event.Detail, &detailData); err != nil {
+		log.Println(err.Error())
+		return nil, err
+	}
+
+	if detailData.InstanceAction != "" {
+		return &detailData.InstanceID, nil
+	}
+
+	return nil, nil
+}
+
+//DetachInstance detaches the instance from autoscaling group without decrementing the desired capacity
+//This makes sure that the autoscaling group spawns a new instance as soon as this instance is detached
+func (s *SpotTermination) DetachInstance(instanceID *string, region string) error {
+
+	log.Printf("Detaching instance %s in region %s", *instanceID, region)
+	if s.asSvc == nil {
+		session := session.Must(
+			session.NewSession(&aws.Config{Region: aws.String(region)}))
+		s.asSvc = autoscaling.New(session)
+	}
+
+	asgName, err := s.getAsgName(instanceID)
+
+	if err != nil {
+		log.Println("Failed to detach instance ", *instanceID)
+		return err
+	}
+
+	detachParams := autoscaling.DetachInstancesInput{
+		AutoScalingGroupName: aws.String(asgName),
+		InstanceIds: []*string{
+			instanceID,
+		},
+		ShouldDecrementDesiredCapacity: aws.Bool(false),
+	}
+	if _, detachErr := s.asSvc.DetachInstances(&detachParams); detachErr != nil {
+		log.Println(detachErr.Error())
+		return detachErr
+	}
+
+	log.Printf("Detached instance %s successfully", *instanceID)
+	return nil
+}
+
+func (s *SpotTermination) getAsgName(instanceID *string) (string, error) {
+
+	asParams := autoscaling.DescribeAutoScalingInstancesInput{
+		InstanceIds: []*string{instanceID},
+	}
+
+	result, err := s.asSvc.DescribeAutoScalingInstances(&asParams)
+
+	if err != nil {
+		log.Println(err.Error())
+		return "", err
+	}
+
+	asgName := *result.AutoScalingInstances[0].AutoScalingGroupName
+	return asgName, err
+}

--- a/core/spot_termination_test.go
+++ b/core/spot_termination_test.go
@@ -1,0 +1,83 @@
+package autospotting
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+)
+
+func TestGetInstanceIDDueForTermination(t *testing.T) {
+
+	expectedInstanceID := "i-123456"
+	dummyInstanceData := instanceData{
+		InstanceID:     expectedInstanceID,
+		InstanceAction: "terminate",
+	}
+
+	tests := []struct {
+		name            string
+		cloudWatchEvent events.CloudWatchEvent
+		expected        *string
+		expectedError   error
+	}{
+		{
+			name: "Detail in event is empty",
+			cloudWatchEvent: events.CloudWatchEvent{
+				Detail: []byte("{}"),
+			},
+			expected:      nil,
+			expectedError: nil,
+		},
+		{
+			name: "Detail has spot termination event data",
+			cloudWatchEvent: events.CloudWatchEvent{
+				Detail: func() json.RawMessage {
+					data, _ := json.Marshal(dummyInstanceData)
+					return data
+				}(),
+			},
+			expected:      &expectedInstanceID,
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			instanceID, err := GetInstanceIDDueForTermination(tc.cloudWatchEvent)
+
+			if err != nil {
+				t.Errorf("Found error: %s", err.Error())
+			}
+
+			if tc.expected == nil && instanceID != nil {
+				t.Errorf("Expected nil instanceID, actual: %s", *instanceID)
+			}
+
+			if tc.expected != nil && *tc.expected != *instanceID {
+				t.Errorf("InstanceID expected: %v\nactual: %v", tc.expected, instanceID)
+			}
+		})
+	}
+}
+
+func TestDetachInstance(t *testing.T) {
+
+	region := "us-east-1"
+	asgName := "dummyASGName"
+	instanceID := "dummyInstanceID"
+	spotTermination := &SpotTermination{
+		asSvc: mockASG{dasio: &autoscaling.DescribeAutoScalingInstancesOutput{
+			AutoScalingInstances: []*autoscaling.InstanceDetails{
+				{
+					AutoScalingGroupName: &asgName,
+				},
+			},
+		}},
+	}
+
+	if err := spotTermination.DetachInstance(&instanceID, region); err != nil {
+		t.Errorf("Error in DetachInstance: %s", err.Error())
+	}
+}


### PR DESCRIPTION
When a spot instance termination event is triggered, the lambda will get the
region and the instance id from the event data. With this data, it will detach
that instance.

# Issue Type

- Feature Pull Request

## Summary

The template now contains another CloudWatch EventRule to trigger the lambda 
when a spot instance termination notification is received.

The lambda detaches the instance when it receives the termination notification from
CloudWatch.

Note: The new EventRule is only present in the cloudformation template. 

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/cristim/autospotting/blob/master/terraform/autospotting.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
