### PR TITLE
Detach instance when spot termination notification is received - event is not from CloudWatch but from SNS #322

### DIFF
--- a/autospotting.go
+++ b/autospotting.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"strings"
-	"encoding/json"
 
 	"github.com/AutoSpotting/AutoSpotting/core"
 	"github.com/aws/aws-lambda-go/events"
@@ -102,7 +102,7 @@ func Handler(ctx context.Context, rawEvent json.RawMessage) {
 	}
 
 	if snsEvent.Records == nil {
-	        run()
+		run()
 	} else {
 		snsRecord := snsEvent.Records[0]
 		snsRegion := strings.Split(snsRecord.EventSubscriptionArn, ":")[3]
@@ -110,18 +110,18 @@ func Handler(ctx context.Context, rawEvent json.RawMessage) {
 		var cloudwatchEvent events.CloudWatchEvent
 
 		if err := json.Unmarshal(snsMessage, &cloudwatchEvent); err != nil {
-		        log.Println(err.Error())
+			log.Println(err.Error())
 			return
 		}
 
 		instanceID, err := autospotting.GetInstanceIDDueForTermination(cloudwatchEvent)
 
 		if err != nil {
-		        return
+			return
 		}
 
 		if instanceID != nil {
-		        spotTermination := autospotting.NewSpotTermination(snsRegion)
+			spotTermination := autospotting.NewSpotTermination(snsRegion)
 			spotTermination.DetachInstance(instanceID)
 		}
 	}

--- a/autospotting.go
+++ b/autospotting.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
+	"encoding/json"
 
 	"github.com/AutoSpotting/AutoSpotting/core"
 	"github.com/aws/aws-lambda-go/events"
@@ -90,19 +92,38 @@ func init() {
 }
 
 // Handler implements the AWS Lambda handler
-func Handler(ctx context.Context, event events.CloudWatchEvent) {
+func Handler(ctx context.Context, rawEvent json.RawMessage) {
 
-	instanceID, err := autospotting.GetInstanceIDDueForTermination(event)
+	var snsEvent events.SNSEvent
 
-	if err != nil {
+	if err := json.Unmarshal(rawEvent, &snsEvent); err != nil {
+		log.Println(err.Error())
 		return
 	}
 
-	if instanceID != nil {
-		spotTermination := autospotting.NewSpotTermination(event.Region)
-		spotTermination.DetachInstance(instanceID)
+	if snsEvent.Records == nil {
+	        run()
 	} else {
-		run()
+		snsRecord := snsEvent.Records[0]
+		snsRegion := strings.Split(snsRecord.EventSubscriptionArn, ":")[3]
+		var snsMessage = []byte(snsRecord.SNS.Message)
+		var cloudwatchEvent events.CloudWatchEvent
+
+		if err := json.Unmarshal(snsMessage, &cloudwatchEvent); err != nil {
+		        log.Println(err.Error())
+			return
+		}
+
+		instanceID, err := autospotting.GetInstanceIDDueForTermination(cloudwatchEvent)
+
+		if err != nil {
+		        return
+		}
+
+		if instanceID != nil {
+		        spotTermination := autospotting.NewSpotTermination(snsRegion)
+			spotTermination.DetachInstance(instanceID)
+		}
 	}
 }
 


### PR DESCRIPTION
# Issue Type

<!--
Pick one below and delete the others.

Also feel free to delete these comments for brevity once they were fully
acknowledged.
-->
- Bugfix Pull Request

## Summary

<!--
Describe the change, including rationale and design decisions, and use a brief
but descriptive PR title.

Please include "Fixes #nnn" here or in your commit message in order to
link to an issue in which you describe the addressed problem in more detail.

If you want to address more issues do it in different pull requests instead of a
single big one, it will speed up the review process considerably.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->

Lambda can be triggered by CloudWatch EventRule (scheduling) or by a SNS
Topic.

In the last case we need to extract the original message, published by
the Termination Notification CloudWatch EventRule, and pass it to
GetInstanceIDDueForTermination.

Fix for #322 

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [ X] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ X] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
