### PR TITLE
Terminate unused spot instances #321

### DIFF
--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -357,7 +357,13 @@ func (a *autoScalingGroup) process() {
 
 	spotInstanceID = *spotInstance.InstanceId
 
-	if !a.needReplaceOnDemandInstances() || !spotInstance.isReadyToAttach(a) {
+	if !a.needReplaceOnDemandInstances() {
+		logger.Println("Spot instance", spotInstanceID, "is not need anymore by ASG",
+			a.name, "terminating the spot instance.")
+		spotInstance.terminate()
+		return
+	}
+	if !spotInstance.isReadyToAttach(a) {
 		logger.Println("Waiting for next run while processing", a.name)
 		return
 	}

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -357,14 +357,14 @@ func (a *autoScalingGroup) process() {
 
 	spotInstanceID = *spotInstance.InstanceId
 
-	if !a.needReplaceOnDemandInstances() {
-		logger.Println("Spot instance", spotInstanceID, "is not need anymore by ASG",
-			a.name, "terminating the spot instance.")
-		spotInstance.terminate()
-		return
-	}
-	if !spotInstance.isReadyToAttach(a) {
-		logger.Println("Waiting for next run while processing", a.name)
+	if !a.needReplaceOnDemandInstances() || !spotInstance.isReadyToAttach(a) {
+		if !a.needReplaceOnDemandInstances() {
+			logger.Println("Spot instance", spotInstanceID, "is not need anymore by ASG",
+				a.name, "terminating the spot instance.")
+			spotInstance.terminate()
+		} else {
+			logger.Println("Waiting for next run while processing", a.name)
+		}
 		return
 	}
 

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -357,14 +357,14 @@ func (a *autoScalingGroup) process() {
 
 	spotInstanceID = *spotInstance.InstanceId
 
-	if !a.needReplaceOnDemandInstances() || !spotInstance.isReadyToAttach(a) {
-		if !a.needReplaceOnDemandInstances() {
-			logger.Println("Spot instance", spotInstanceID, "is not need anymore by ASG",
-				a.name, "terminating the spot instance.")
-			spotInstance.terminate()
-		} else {
-			logger.Println("Waiting for next run while processing", a.name)
-		}
+	if !a.needReplaceOnDemandInstances() {
+		logger.Println("Spot instance", spotInstanceID, "is not need anymore by ASG",
+			a.name, "terminating the spot instance.")
+		spotInstance.terminate()
+		return
+	}
+	if !spotInstance.isReadyToAttach(a) {
+		logger.Println("Waiting for next run while processing", a.name)
 		return
 	}
 


### PR DESCRIPTION
# Issue Type

<!--
Pick one below and delete the others.

Also feel free to delete these comments for brevity once they were fully
acknowledged.
-->

- Feature Pull Request

## Summary

<!--
Describe the change, including rationale and design decisions, and use a brief
but descriptive PR title.

Please include "Fixes #nnn" here or in your commit message in order to
link to an issue in which you describe the addressed problem in more detail.

If you want to address more issues do it in different pull requests instead of a
single big one, it will speed up the review process considerably.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->

Currently.
A spotted instance is launched.
Before the next autospot execution the ondemand instance that autospot
next execution should have replaced is terminated.
The launched spot instance, that is no more necessary, is not terminated.

The idea is:
once we found a spot instance launched for an ASG, we first check if the
ASG still need it.
If not we terminate the spot instance.
Beacuse we cannot know if the ASG will need it in the future and after
how much time.

To test:
create an ASG with min=max=desired=1
wait until autospot launch a spot for that ASG
set min=desired=0
look at next autospot execution log for a line like:
```
2019/02/15 13:33:24 autoscaling.go:366: Spot instance i-0fa844e5c281023a0 is not need anymore by ASG ecs-s-d-AutoScalingGroup-DLZ9BYSWB9V4 terminating the spot instance.
```
check that launched spot instance is terminated.

fix #321

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [X ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ X] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ X] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [x] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [x] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
