### PR TITLE
Termination Notification Configurable Action

### DIFF
--- a/autospotting.go
+++ b/autospotting.go
@@ -49,7 +49,8 @@ func run() {
 		"tag_filters=%s "+
 		"tag_filter_mode=%s "+
 		"spot_product_description=%v "+
-		"instance_termination_method=%s\n",
+		"instance_termination_method=%s "+
+		"termination_notification_action=%s\n",
 		conf.Regions,
 		conf.MinOnDemandNumber,
 		conf.MinOnDemandPercentage,
@@ -61,7 +62,8 @@ func run() {
 		conf.FilterByTags,
 		conf.TagFilteringMode,
 		conf.SpotProductDescription,
-		conf.InstanceTerminationMethod)
+		conf.InstanceTerminationMethod,
+		conf.TerminationNotificationAction)
 
 	autospotting.Run(conf.Config)
 	log.Println("Execution completed, nothing left to do")
@@ -122,7 +124,7 @@ func Handler(ctx context.Context, rawEvent json.RawMessage) {
 
 		if instanceID != nil {
 			spotTermination := autospotting.NewSpotTermination(snsRegion)
-			spotTermination.DetachInstance(instanceID)
+			spotTermination.ExecuteAction(instanceID, conf.TerminationNotificationAction)
 		}
 	}
 }
@@ -155,6 +157,12 @@ func (c *cfgData) parseCommandLineFlags() {
 	flag.StringVar(&c.InstanceTerminationMethod, "instance_termination_method", autospotting.DefaultInstanceTerminationMethod,
 		"\n\tInstance termination method.  Must be one of '"+autospotting.DefaultInstanceTerminationMethod+"' (default),\n"+
 			"\t or 'detach' (compatibility mode, not recommended)\n")
+	flag.StringVar(&c.TerminationNotificationAction, "termination_notification_action", autospotting.DefaultTerminationNotificationAction,
+		"\n\tTermination Notification Action.\n"+
+			"\tValid choices:\n"+
+			"\t'"+autospotting.DefaultTerminationNotificationAction+
+			"' (terminate if lifecyclehook else detach) | 'terminate' (lifecyclehook triggered)"+
+			" | 'detach' (lifecyclehook not triggered)\n")
 	flag.Int64Var(&c.MinOnDemandNumber, "min_on_demand_number", autospotting.DefaultMinOnDemandValue,
 		"\n\tNumber of on-demand nodes to be kept running in each of the groups.\n\t"+
 			"Can be overridden on a per-group basis using the tag "+autospotting.OnDemandNumberLong+".\n")

--- a/cloudformation/stacks/AutoSpotting/template.yaml
+++ b/cloudformation/stacks/AutoSpotting/template.yaml
@@ -40,6 +40,17 @@
         "Instance termination method.  Must be one of 'autoscaling' (default) or
         'detach' (compatibility mode, not recommended)"
       Type: "String"
+    TerminationNotificationAction:
+      AllowedValues:
+        - "auto"
+        - "detach"
+        - "terminate"
+      Default: "terminate"
+      Description: >
+        "Action to do when receiving a Spot Instance Termination Notification.
+        Must be one of 'auto' (terminate if lifecyclehook else detach) [default],
+        'terminate' (lifecyclehook triggered), 'detach' (lifecyclehook not triggered)"
+      Type: "String"
     FilterByTags:
       Default: ""
       Description: >
@@ -195,6 +206,8 @@
               Ref: "TagFilteringMode"
             TAG_FILTERS:
               Ref: "FilterByTags"
+            TERMINATION_NOTIFICATION_ACTION:
+              Ref: "TerminationNotificationAction"
         Handler:
           Ref: "LambdaHandlerFunction"
         MemorySize:
@@ -226,6 +239,7 @@
                 - "autoscaling:DetachInstances"
                 - "autoscaling:TerminateInstanceInAutoScalingGroup"
                 - "autoscaling:UpdateAutoScalingGroup"
+                - "autoscaling:DescribeLifecycleHooks"
                 - "cloudformation:CreateStack"
                 - "cloudformation:DeleteStack"
                 - "cloudformation:Describe*"

--- a/cloudformation/stacks/AutoSpotting/template.yaml
+++ b/cloudformation/stacks/AutoSpotting/template.yaml
@@ -45,7 +45,7 @@
         - "auto"
         - "detach"
         - "terminate"
-      Default: "terminate"
+      Default: "auto"
       Description: >
         "Action to do when receiving a Spot Instance Termination Notification.
         Must be one of 'auto' (terminate if lifecyclehook else detach) [default],

--- a/core/config.go
+++ b/core/config.go
@@ -19,6 +19,20 @@ const (
 	// and then terminates it.  This method exists for historical reasons and is
 	// no longer recommended.
 	DetachTerminationMethod = "detach"
+
+	// TerminateTerminationNotificationAction terminate the spot instance, which will be terminated
+	// by AWS in 2 minutes, without reducing the ASG capcity, so that a new instance will 
+	// be launched. LifeCycle Hooks are triggered.
+	TerminateTerminationNotificationAction = "terminate"
+
+	// DetachTerminationNotificationAction detach the spot instance, which will be terminated
+	// by AWS in 2 minutes, without reducing the ASG capcity, so that a new instance will 
+	// be launched. LifeCycle Hooks are not triggered.
+	DetachTerminationNotificationAction =  "detach"
+
+	// AutoTerminationNotificationAction if ASG has a LifeCycleHook with LifecycleTransition = EC2_INSTANCE_TERMINATING
+	// terminate the spot instance (as TerminateTerminationNotificationAction), if not detach it.
+	AutoTerminationNotificationAction =  "auto"
 )
 
 // Config contains a number of flags and static data storing the EC2 instance
@@ -59,4 +73,7 @@ type Config struct {
 
 	// Instance termination method
 	InstanceTerminationMethod string
+
+	// Termination Notification action
+	TerminationNotificationAction string
 }

--- a/core/config.go
+++ b/core/config.go
@@ -21,18 +21,18 @@ const (
 	DetachTerminationMethod = "detach"
 
 	// TerminateTerminationNotificationAction terminate the spot instance, which will be terminated
-	// by AWS in 2 minutes, without reducing the ASG capcity, so that a new instance will 
+	// by AWS in 2 minutes, without reducing the ASG capcity, so that a new instance will
 	// be launched. LifeCycle Hooks are triggered.
 	TerminateTerminationNotificationAction = "terminate"
 
 	// DetachTerminationNotificationAction detach the spot instance, which will be terminated
-	// by AWS in 2 minutes, without reducing the ASG capcity, so that a new instance will 
+	// by AWS in 2 minutes, without reducing the ASG capcity, so that a new instance will
 	// be launched. LifeCycle Hooks are not triggered.
-	DetachTerminationNotificationAction =  "detach"
+	DetachTerminationNotificationAction = "detach"
 
 	// AutoTerminationNotificationAction if ASG has a LifeCycleHook with LifecycleTransition = EC2_INSTANCE_TERMINATING
 	// terminate the spot instance (as TerminateTerminationNotificationAction), if not detach it.
-	AutoTerminationNotificationAction =  "auto"
+	AutoTerminationNotificationAction = "auto"
 )
 
 // Config contains a number of flags and static data storing the EC2 instance

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -136,6 +136,10 @@ type mockASG struct {
 	// Describe AutoScalingInstances
 	dasio   *autoscaling.DescribeAutoScalingInstancesOutput
 	dasierr error
+
+	// DescribeLifecycleHooks
+	dlho   *autoscaling.DescribeLifecycleHooksOutput
+	dlherr error
 }
 
 func (m mockASG) DetachInstances(*autoscaling.DetachInstancesInput) (*autoscaling.DetachInstancesOutput, error) {
@@ -170,4 +174,8 @@ func (m mockASG) DescribeAutoScalingGroupsPages(input *autoscaling.DescribeAutoS
 
 func (m mockASG) DescribeAutoScalingInstances(inout *autoscaling.DescribeAutoScalingInstancesInput) (*autoscaling.DescribeAutoScalingInstancesOutput, error) {
 	return m.dasio, m.dasierr
+}
+
+func (m mockASG) DescribeLifecycleHooks(*autoscaling.DescribeLifecycleHooksInput) (*autoscaling.DescribeLifecycleHooksOutput, error) {
+	return m.dlho, m.dlherr
 }

--- a/core/spot_termination.go
+++ b/core/spot_termination.go
@@ -117,7 +117,7 @@ func (s *SpotTermination) getAsgName(instanceID *string) (string, error) {
 	return asgName, err
 }
 
-// ExecuteAction execute the proper termination action (terminate|detach) based on the value of 
+// ExecuteAction execute the proper termination action (terminate|detach) based on the value of
 // terminationNotificationAction and the presence of a LifecycleHook on ASG.
 func (s *SpotTermination) ExecuteAction(instanceID *string, terminationNotificationAction string) error {
 	if s.asSvc == nil {

--- a/core/spot_termination.go
+++ b/core/spot_termination.go
@@ -137,7 +137,7 @@ func (s *SpotTermination) ExecuteAction(instanceID *string, terminationNotificat
 	case "terminate":
 		s.terminateInstance(instanceID, asgName)
 	default:
-		if s.asgHasHook(&asgName) {
+		if s.asgHasTerminationLifecycleHook(&asgName) {
 			s.terminateInstance(instanceID, asgName)
 		} else {
 			s.detachInstance(instanceID, asgName)
@@ -147,7 +147,7 @@ func (s *SpotTermination) ExecuteAction(instanceID *string, terminationNotificat
 	return nil
 }
 
-func (s *SpotTermination) asgHasHook(autoScalingGroupName *string) bool {
+func (s *SpotTermination) asgHasTerminationLifecycleHook(autoScalingGroupName *string) bool {
 	asParams := autoscaling.DescribeLifecycleHooksInput{
 		AutoScalingGroupName: autoScalingGroupName,
 	}

--- a/core/spot_termination.go
+++ b/core/spot_termination.go
@@ -12,6 +12,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 )
 
+const (
+	// DefaultTerminationNotificationAction is the default value for the termination notification
+	// action configuration option
+	DefaultTerminationNotificationAction = AutoTerminationNotificationAction
+)
+
 //SpotTermination is used to detach an instance, used when a spot instance is due for termination
 type SpotTermination struct {
 	asSvc autoscalingiface.AutoScalingAPI
@@ -57,18 +63,7 @@ func GetInstanceIDDueForTermination(event events.CloudWatchEvent) (*string, erro
 
 //DetachInstance detaches the instance from autoscaling group without decrementing the desired capacity
 //This makes sure that the autoscaling group spawns a new instance as soon as this instance is detached
-func (s *SpotTermination) DetachInstance(instanceID *string) error {
-
-	if s.asSvc == nil {
-		return errors.New("AutoScaling service not defined. Please use NewSpotTermination()")
-	}
-
-	asgName, err := s.getAsgName(instanceID)
-
-	if err != nil {
-		log.Printf("Failed to detach instance %s with err: %s\n", err.Error(), *instanceID)
-		return err
-	}
+func (s *SpotTermination) DetachInstance(instanceID *string, asgName string) error {
 
 	detachParams := autoscaling.DetachInstancesInput{
 		AutoScalingGroupName: aws.String(asgName),
@@ -86,8 +81,28 @@ func (s *SpotTermination) DetachInstance(instanceID *string) error {
 	return nil
 }
 
-func (s *SpotTermination) getAsgName(instanceID *string) (string, error) {
+//TerminateInstance terminate the instance from autoscaling group without decrementing the desired capacity
+//This makes sure that any LifeCycle Hook configured is triggered and the autoscaling group spawns a new instance
+// as soon as this instance begin terminating.
+func (s *SpotTermination) TerminateInstance(instanceID *string, asgName string) error {
 
+	log.Println(asgName,
+		"Terminating instance:",
+		*instanceID)
+	// terminate the spot instance
+	terminateParams := autoscaling.TerminateInstanceInAutoScalingGroupInput{
+		InstanceId:                     instanceID,
+		ShouldDecrementDesiredCapacity: aws.Bool(false),
+	}
+
+	if _, err := s.asSvc.TerminateInstanceInAutoScalingGroup(&terminateParams); err != nil {
+		logger.Println(err.Error())
+		return err
+	}
+	return nil
+}
+
+func (s *SpotTermination) getAsgName(instanceID *string) (string, error) {
 	asParams := autoscaling.DescribeAutoScalingInstancesInput{
 		InstanceIds: []*string{instanceID},
 	}
@@ -100,4 +115,56 @@ func (s *SpotTermination) getAsgName(instanceID *string) (string, error) {
 	}
 
 	return asgName, err
+}
+
+func (s *SpotTermination) ExecuteAction(instanceID *string, terminationNotificationAction string) error {
+	if s.asSvc == nil {
+		return errors.New("AutoScaling service not defined. Please use NewSpotTermination()")
+	}
+
+	asgName, err := s.getAsgName(instanceID)
+
+	if err != nil {
+		log.Printf("Failed get ASG name for %s with err: %s\n", *instanceID, err.Error())
+		return err
+	}
+
+	switch terminationNotificationAction {
+	case "detach":
+		s.DetachInstance(instanceID, asgName)
+	case "terminate":
+		s.TerminateInstance(instanceID, asgName)
+	default:
+		if s.AsgHasHook(&asgName) {
+			s.TerminateInstance(instanceID, asgName)
+		} else {
+			s.DetachInstance(instanceID, asgName)
+		}
+	}
+
+	return nil
+}
+
+func (s *SpotTermination) AsgHasHook(autoScalingGroupName *string) bool {
+	asParams := autoscaling.DescribeLifecycleHooksInput{
+		AutoScalingGroupName: autoScalingGroupName,
+	}
+
+	result, err := s.asSvc.DescribeLifecycleHooks(&asParams)
+
+	if err != nil {
+		logger.Println(err.Error())
+		return false
+	}
+
+	var hasHook = false
+	for _, lfh := range result.LifecycleHooks {
+		if *lfh.LifecycleTransition == "autoscaling:EC2_INSTANCE_TERMINATING" {
+			hasHook = true
+			logger.Println("Found Hook", *lfh.LifecycleHookName)
+			break
+		}
+	}
+
+	return hasHook
 }

--- a/core/spot_termination_test.go
+++ b/core/spot_termination_test.go
@@ -75,7 +75,7 @@ func TestGetInstanceIDDueForTermination(t *testing.T) {
 	}
 }
 
-func TestdetachInstance(t *testing.T) {
+func TestDetachInstance(t *testing.T) {
 
 	asgName := "dummyASGName"
 	instanceID := "dummyInstanceID"
@@ -122,7 +122,7 @@ func TestdetachInstance(t *testing.T) {
 	}
 }
 
-func TestterminateInstance(t *testing.T) {
+func TestTerminateInstance(t *testing.T) {
 
 	asgName := "dummyASGName"
 	instanceID := "dummyInstanceID"
@@ -165,7 +165,7 @@ func TestterminateInstance(t *testing.T) {
 	}
 }
 
-func TestgetAsgName(t *testing.T) {
+func TestGetAsgName(t *testing.T) {
 	asgName := "dummyASGName"
 	instanceID := "dummyInstanceID"
 

--- a/core/spot_termination_test.go
+++ b/core/spot_termination_test.go
@@ -75,7 +75,7 @@ func TestGetInstanceIDDueForTermination(t *testing.T) {
 	}
 }
 
-func TestDetachInstance(t *testing.T) {
+func TestdetachInstance(t *testing.T) {
 
 	asgName := "dummyASGName"
 	instanceID := "dummyInstanceID"
@@ -113,7 +113,7 @@ func TestDetachInstance(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.spotTermination.DetachInstance(&instanceID, asgName)
+			err := tc.spotTermination.detachInstance(&instanceID, asgName)
 			if err != nil && err.Error() != tc.expectedError.Error() {
 				t.Errorf("Error in DetachInstance: expected %s actual %s", tc.expectedError.Error(), err.Error())
 			}
@@ -122,7 +122,7 @@ func TestDetachInstance(t *testing.T) {
 	}
 }
 
-func TestTerminateInstance(t *testing.T) {
+func TestterminateInstance(t *testing.T) {
 
 	asgName := "dummyASGName"
 	instanceID := "dummyInstanceID"
@@ -156,7 +156,7 @@ func TestTerminateInstance(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.spotTermination.TerminateInstance(&instanceID, asgName)
+			err := tc.spotTermination.terminateInstance(&instanceID, asgName)
 			if err != nil && err.Error() != tc.expectedError.Error() {
 				t.Errorf("Error in TerminateInstance: expected %s actual %s", tc.expectedError.Error(), err.Error())
 			}


### PR DESCRIPTION

# Issue Type

<!--
Pick one below and delete the others.

Also feel free to delete these comments for brevity once they were fully
acknowledged.
-->

- Feature Pull Request

## Summary

<!--
Describe the change, including rationale and design decisions, and use a brief
but descriptive PR title.

Please include "Fixes #nnn" here or in your commit message in order to
link to an issue in which you describe the addressed problem in more detail.

If you want to address more issues do it in different pull requests instead of a
single big one, it will speed up the review process considerably.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->
Idea:
At the moment, when a termination notification message is received,
we are only supporting detach as action on the terminating spot instance.

Detaching an instance do not trigger Lifecycle Hook (LH).

This patch add a new option "termination_notification_action" with
relative CloudFormation parameter "TerminationNotificationAction" that
support the options:
```
detach
	current behaviour - no LH Triggered
terminate
	new behaviour - spot instance is terminated without decrementing
	desired capacity, so that ASG spawn a new instance (same as detach) - LH
	Triggered.
auto
	new behaviour - if ASG has a LH for Terminate Lifecycle
	Transition, action is "terminate", if not action is detach.
```
The option is global for all ASG.
But using "auto", behaviour is based on the presence of LH, this way it
can act in different ways.

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [x] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
