### PR TITLE
Delete Tag 'launched-for-asg' when detaching a spot instance

### DIFF
--- a/cloudformation/stacks/AutoSpotting/template.yaml
+++ b/cloudformation/stacks/AutoSpotting/template.yaml
@@ -244,6 +244,7 @@
                 - "cloudformation:DeleteStack"
                 - "cloudformation:Describe*"
                 - "ec2:CreateTags"
+                - "ec2:DeleteTags"
                 - "ec2:DescribeInstanceAttribute"
                 - "ec2:DescribeInstances"
                 - "ec2:DescribeRegions"

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -45,6 +45,10 @@ type mockEC2 struct {
 	// Describe Regions
 	dro   *ec2.DescribeRegionsOutput
 	drerr error
+
+	// Delete Tags
+	dto *ec2.DeleteTagsOutput
+	dterr error
 }
 
 func (m mockEC2) DescribeSpotPriceHistory(in *ec2.DescribeSpotPriceHistoryInput) (*ec2.DescribeSpotPriceHistoryOutput, error) {
@@ -66,6 +70,10 @@ func (m mockEC2) TerminateInstances(*ec2.TerminateInstancesInput) (*ec2.Terminat
 
 func (m mockEC2) DescribeRegions(*ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error) {
 	return m.dro, m.drerr
+}
+
+func (m mockEC2) DeleteTags(*ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error) {
+	return m.dto, m.dterr
 }
 
 // For testing we "convert" the SecurityGroupIDs/SecurityGroupNames by

--- a/core/spot_termination.go
+++ b/core/spot_termination.go
@@ -172,7 +172,7 @@ func (s *SpotTermination) deleteTagInstanceLaunchedForAsg(instanceID *string) er
 		return err
 	}
 
-	log.Printf("Tag 'launched-for-asg' delete from spot instance %s", *instanceID)
+	log.Printf("Tag 'launched-for-asg' deleted from spot instance %s", *instanceID)
 
 	return nil
 }


### PR DESCRIPTION
# Issue Type

<!--
Pick one below and delete the others.

Also feel free to delete these comments for brevity once they were fully
acknowledged.
-->

- Bugfix Pull Request


## Summary

<!--
Describe the change, including rationale and design decisions, and use a brief
but descriptive PR title.

Please include "Fixes #nnn" here or in your commit message in order to
link to an issue in which you describe the addressed problem in more detail.

If you want to address more issues do it in different pull requests instead of a
single big one, it will speed up the review process considerably.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->

In some situation (described in detail in #327), a detaching near termination
spot instance can be used to replace an ondemand one.

This fix delete the Tag 'launched-for-asg' after successfully detaching
a spot instance.

Fixes #327


## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [X] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [X] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
