### PR TITLE
Support launch templates with network configuration

### DIFF
--- a/cloudformation/stacks/AutoSpotting/template.yaml
+++ b/cloudformation/stacks/AutoSpotting/template.yaml
@@ -319,7 +319,7 @@
                     "}"
                   ]
                 ]
-              - !Ref 'AWS::NoValue' 
+              - !Ref 'AWS::NoValue'
             Arn: !If
               - "StackSetsIsRegional"
               - Fn::GetAtt:
@@ -447,6 +447,7 @@
                 - "ec2:DeleteTags"
                 - "ec2:DescribeInstanceAttribute"
                 - "ec2:DescribeInstances"
+                - "ec2:DescribeLaunchTemplateVersions"
                 - "ec2:DescribeRegions"
                 - "ec2:DescribeSpotPriceHistory"
                 - "ec2:RunInstances"

--- a/core/instance.go
+++ b/core/instance.go
@@ -514,8 +514,8 @@ func (i *instance) launchTemplateHasNetworkInterfaces(ver, id *string) bool {
 	)
 
 	if err != nil {
-    logger.Println("Failed to describe launch template", *id, "version", *ver,
-    "encountered error:", err.Error())
+		logger.Println("Failed to describe launch template", *id, "version", *ver,
+			"encountered error:", err.Error())
 	}
 
 	if err == nil && len(res.LaunchTemplateVersions) == 1 {

--- a/core/instance.go
+++ b/core/instance.go
@@ -505,6 +505,27 @@ func (i *instance) convertSecurityGroups() []*string {
 	return groupIDs
 }
 
+func (i *instance) launchTemplateHasNetworkInterfaces(ver, id *string) bool {
+	res, err := i.region.services.ec2.DescribeLaunchTemplateVersions(
+		&ec2.DescribeLaunchTemplateVersionsInput{
+			Versions:         []*string{ver},
+			LaunchTemplateId: id,
+		},
+	)
+
+	if err != nil {
+		logger.Println("Failed to describe launch template", *id, "version", *ver)
+	}
+
+	if err == nil && len(res.LaunchTemplateVersions) == 1 {
+		lt := res.LaunchTemplateVersions[0]
+		if len(lt.LaunchTemplateData.NetworkInterfaces) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func (i *instance) createRunInstancesInput(instanceType string, price float64) *ec2.RunInstancesInput {
 	var retval ec2.RunInstancesInput
 
@@ -537,9 +558,16 @@ func (i *instance) createRunInstancesInput(instanceType string, price float64) *
 	}
 
 	if i.asg.LaunchTemplate != nil {
+		ver := i.asg.LaunchTemplate.Version
+		id := i.asg.LaunchTemplate.LaunchTemplateId
+
 		retval.LaunchTemplate = &ec2.LaunchTemplateSpecification{
-			LaunchTemplateId: i.asg.LaunchTemplate.LaunchTemplateId,
-			Version:          i.asg.LaunchTemplate.Version,
+			LaunchTemplateId: id,
+			Version:          ver,
+		}
+
+		if i.launchTemplateHasNetworkInterfaces(id, ver) {
+			retval.SubnetId, retval.SecurityGroupIds = nil, nil
 		}
 	}
 

--- a/core/instance.go
+++ b/core/instance.go
@@ -514,7 +514,8 @@ func (i *instance) launchTemplateHasNetworkInterfaces(ver, id *string) bool {
 	)
 
 	if err != nil {
-		logger.Println("Failed to describe launch template", *id, "version", *ver)
+    logger.Println("Failed to describe launch template", *id, "version", *ver,
+    "encountered error:", err.Error())
 	}
 
 	if err == nil && len(res.LaunchTemplateVersions) == 1 {

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -51,6 +51,10 @@ type mockEC2 struct {
 	// Delete Tags
 	dto   *ec2.DeleteTagsOutput
 	dterr error
+
+	// DescribeLaunchTemplateVersionsOutput
+	dltvo   *ec2.DescribeLaunchTemplateVersionsOutput
+	dltverr error
 }
 
 func (m mockEC2) DescribeSpotPriceHistory(in *ec2.DescribeSpotPriceHistoryInput) (*ec2.DescribeSpotPriceHistoryOutput, error) {
@@ -76,6 +80,10 @@ func (m mockEC2) DescribeRegions(*ec2.DescribeRegionsInput) (*ec2.DescribeRegion
 
 func (m mockEC2) DeleteTags(*ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error) {
 	return m.dto, m.dterr
+}
+
+func (m mockEC2) DescribeLaunchTemplateVersions(*ec2.DescribeLaunchTemplateVersionsInput) (*ec2.DescribeLaunchTemplateVersionsOutput, error) {
+	return m.dltvo, m.dltverr
 }
 
 // For testing we "convert" the SecurityGroupIDs/SecurityGroupNames by


### PR DESCRIPTION
# Issue Type

<!--
Pick one below and delete the others.

Also feel free to delete these comments for brevity once they were fully
acknowledged.
-->

- Bugfix Pull Request

## Summary

The RunInstances input needs to be cleaned from any attributes conflicting with Network interface definition coming from the group's LaunchTemplate.

I also tidied up the tests since in the real world LaunchTemplates can't be configured together with LaunchConfigurations on the same ASG.

This hopefully fixes #345 but needs to be tested and confirmed.

<!--
Describe the change, including rationale and design decisions, and use a brief
but descriptive PR title.

Please include "Fixes #nnn" here or in your commit message in order to
link to an issue in which you describe the addressed problem in more detail.

If you want to address more issues do it in different pull requests instead of a
single big one, it will speed up the review process considerably.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [N/A] Functionality not applicable to all users should be configurable.
1. [N/A] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [N/A] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [N/A] Tags names and expected values should be similar to the other existing
   configurations.
1. [N/A] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [N/A] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [N/A] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
