### PR TITLE
Enable Spot Termination ASG Checking

### DIFF
--- a/core/main.go
+++ b/core/main.go
@@ -213,7 +213,7 @@ func (a *AutoSpotting) EventHandler(event *json.RawMessage) {
 			if spotTermination.isInAutoSpottingASG(instanceID, a.config.TagFilteringMode, a.config.FilterByTags) {
 				spotTermination.executeAction(instanceID, a.config.TerminationNotificationAction)
 			} else {
-				log.Println("Instance is not in AutoSpotting ASG")
+				log.Printf("Instance %s is not in AutoSpotting ASG\n", *instanceID)
 				return
 			}
 		}

--- a/core/main.go
+++ b/core/main.go
@@ -210,7 +210,8 @@ func (a *AutoSpotting) EventHandler(event *json.RawMessage) {
 			return
 		} else if instanceID != nil {
 			spotTermination := newSpotTermination(cloudwatchEvent.Region)
-			spotTermination.executeAction(instanceID, a.config.TerminationNotificationAction)
+			// here
+			spotTermination.executeAction(instanceID, a.config.TerminationNotificationAction, a.config.TagFilteringMode, a.config.FilterByTags)
 		}
 
 		// If event is Instance state change

--- a/core/main.go
+++ b/core/main.go
@@ -210,8 +210,12 @@ func (a *AutoSpotting) EventHandler(event *json.RawMessage) {
 			return
 		} else if instanceID != nil {
 			spotTermination := newSpotTermination(cloudwatchEvent.Region)
-			// here
-			spotTermination.executeAction(instanceID, a.config.TerminationNotificationAction, a.config.TagFilteringMode, a.config.FilterByTags)
+			if spotTermination.isInAutoSpottingASG(instanceID, a.config.TagFilteringMode, a.config.FilterByTags) {
+				spotTermination.executeAction(instanceID, a.config.TerminationNotificationAction)
+			} else {
+				log.Println("Instance is not in AutoSpotting ASG")
+				return
+			}
 		}
 
 		// If event is Instance state change

--- a/core/spot_termination.go
+++ b/core/spot_termination.go
@@ -217,7 +217,6 @@ func (s *SpotTermination) isInAutoSpottingASG(instanceID *string, tagFilteringMo
 		return false
 	}
 
-	logger.Printf("starting logic for ASG")
 	asgGroupsOutput, err := s.asSvc.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: []*string{
 			&asgName,
@@ -233,19 +232,11 @@ func (s *SpotTermination) isInAutoSpottingASG(instanceID *string, tagFilteringMo
 
 	var tagsToMatch = []Tag{}
 
-	if len(filters) == 0 {
-		tagsToMatch = []Tag{{Key: "spot-enabled", Value: "true"}}
-	}
-
 	for _, tagWithValue := range strings.Split(filters, ",") {
 		tag := splitTagAndValue(tagWithValue)
 		if tag != nil {
 			tagsToMatch = append(tagsToMatch, *tag)
 		}
-	}
-
-	if len(tagsToMatch) == 0 {
-		tagsToMatch = []Tag{{Key: "spot-enabled", Value: "true"}}
 	}
 
 	groupMatchesExpectedTags := isASGWithMatchingTags(asgGroupsOutput.AutoScalingGroups[0], tagsToMatch)

--- a/core/spot_termination.go
+++ b/core/spot_termination.go
@@ -130,12 +130,12 @@ func (s *SpotTermination) getAsgName(instanceID *string) (string, error) {
 
 // ExecuteAction execute the proper termination action (terminate|detach) based on the value of
 // terminationNotificationAction and the presence of a LifecycleHook on ASG.
-func (s *SpotTermination) executeAction(instanceID *string, terminationNotificationAction string, tagFilteringMode string, filterByTags string) error {
+func (s *SpotTermination) executeAction(instanceID *string, terminationNotificationAction string) error {
 	if s.asSvc == nil {
 		return errors.New("AutoScaling service not defined. Please use NewSpotTermination()")
 	}
 
-	var optInFilterMode = (tagFilteringMode != "opt-out")
+	// var optInFilterMode = (tagFilteringMode != "opt-out")
 
 	asgName, err := s.getAsgName(instanceID)
 
@@ -144,44 +144,46 @@ func (s *SpotTermination) executeAction(instanceID *string, terminationNotificat
 		return err
 	}
 
-	debug.Printf("starting logic for ASG")
-	svc := s.asSvc
-	asgGroupsOutput, err := svc.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
-		AutoScalingGroupNames: []*string{
-			&asgName,
-		},
-	})
-
-	if err != nil {
-		logger.Printf("Error: %s\n", err.Error())
-	}
-
-	filters := replaceWhitespace(filterByTags)
-
-	var tagsToMatch = []Tag{}
-
-	if len(filters) == 0 {
-		tagsToMatch = []Tag{{Key: "spot-enabled", Value: "true"}}
-	}
-
-	for _, tagWithValue := range strings.Split(filters, ",") {
-		tag := splitTagAndValue(tagWithValue)
-		if tag != nil {
-			tagsToMatch = append(tagsToMatch, *tag)
-		}
-	}
-
-	if len(tagsToMatch) == 0 {
-		tagsToMatch = []Tag{{Key: "spot-enabled", Value: "true"}}
-	}
-
-	groupMatchesExpectedTags := isASGWithMatchingTags(asgGroupsOutput.AutoScalingGroups[0], tagsToMatch)
-
-	if optInFilterMode != groupMatchesExpectedTags {
-		debug.Printf("Skipping group %s because its tags, the currently "+
-			"configured filtering mode (%s) and tag filters do not align\n",
-			asgName, tagFilteringMode)
-	}
+	// logger.Printf("starting logic for ASG")
+	// svc := autoscaling.New(session.New())
+	// asgGroupsOutput, err := svc.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+	// 	AutoScalingGroupNames: []*string{
+	// 		&asgName,
+	// 	},
+	// })
+	//
+	// if err != nil {
+	// 	logger.Printf("Failed to get ASG using ASG name %s with err: %s\n", asgName, err.Error())
+	// 	return err
+	// }
+	//
+	// filters := replaceWhitespace(filterByTags)
+	//
+	// var tagsToMatch = []Tag{}
+	//
+	// if len(filters) == 0 {
+	// 	tagsToMatch = []Tag{{Key: "spot-enabled", Value: "true"}}
+	// }
+	//
+	// for _, tagWithValue := range strings.Split(filters, ",") {
+	// 	tag := splitTagAndValue(tagWithValue)
+	// 	if tag != nil {
+	// 		tagsToMatch = append(tagsToMatch, *tag)
+	// 	}
+	// }
+	//
+	// if len(tagsToMatch) == 0 {
+	// 	tagsToMatch = []Tag{{Key: "spot-enabled", Value: "true"}}
+	// }
+	//
+	// groupMatchesExpectedTags := isASGWithMatchingTags(asgGroupsOutput.AutoScalingGroups[0], tagsToMatch)
+	//
+	// if optInFilterMode != groupMatchesExpectedTags {
+	// 	logger.Printf("Skipping group %s because its tags, the currently "+
+	// 		"configured filtering mode (%s) and tag filters do not align\n",
+	// 		asgName, tagFilteringMode)
+	// 	return nil
+	// }
 
 	switch terminationNotificationAction {
 	case "detach":
@@ -244,4 +246,59 @@ func (s *SpotTermination) asgHasTerminationLifecycleHook(autoScalingGroupName *s
 	}
 
 	return hasHook
+}
+
+// Checks to see whether an instance is in an AutoSpotting ASG as defined by tags
+// If the ASG does not have the required tags, it is not an AutoSpotting ASG and should be left
+func (s *SpotTermination) isInAutoSpottingASG(instanceID *string, tagFilteringMode string, filterByTags string) bool {
+	var optInFilterMode = (tagFilteringMode != "opt-out")
+
+	asgName, err := s.getAsgName(instanceID)
+
+	if err != nil {
+		logger.Printf("Failed get ASG name for %s with err: %s\n", *instanceID, err.Error())
+		return false
+	}
+
+	logger.Printf("starting logic for ASG")
+	asgGroupsOutput, err := s.asSvc.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{
+			&asgName,
+		},
+	})
+
+	if err != nil {
+		logger.Printf("Failed to get ASG using ASG name %s with err: %s\n", asgName, err.Error())
+		return false
+	}
+
+	filters := replaceWhitespace(filterByTags)
+
+	var tagsToMatch = []Tag{}
+
+	if len(filters) == 0 {
+		tagsToMatch = []Tag{{Key: "spot-enabled", Value: "true"}}
+	}
+
+	for _, tagWithValue := range strings.Split(filters, ",") {
+		tag := splitTagAndValue(tagWithValue)
+		if tag != nil {
+			tagsToMatch = append(tagsToMatch, *tag)
+		}
+	}
+
+	if len(tagsToMatch) == 0 {
+		tagsToMatch = []Tag{{Key: "spot-enabled", Value: "true"}}
+	}
+
+	groupMatchesExpectedTags := isASGWithMatchingTags(asgGroupsOutput.AutoScalingGroups[0], tagsToMatch)
+
+	if optInFilterMode != groupMatchesExpectedTags {
+		logger.Printf("Skipping group %s because its tags, the currently "+
+			"configured filtering mode (%s) and tag filters do not align\n",
+			asgName, tagFilteringMode)
+		return false
+	}
+
+	return true
 }

--- a/core/spot_termination.go
+++ b/core/spot_termination.go
@@ -135,55 +135,12 @@ func (s *SpotTermination) executeAction(instanceID *string, terminationNotificat
 		return errors.New("AutoScaling service not defined. Please use NewSpotTermination()")
 	}
 
-	// var optInFilterMode = (tagFilteringMode != "opt-out")
-
 	asgName, err := s.getAsgName(instanceID)
 
 	if err != nil {
 		logger.Printf("Failed get ASG name for %s with err: %s\n", *instanceID, err.Error())
 		return err
 	}
-
-	// logger.Printf("starting logic for ASG")
-	// svc := autoscaling.New(session.New())
-	// asgGroupsOutput, err := svc.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
-	// 	AutoScalingGroupNames: []*string{
-	// 		&asgName,
-	// 	},
-	// })
-	//
-	// if err != nil {
-	// 	logger.Printf("Failed to get ASG using ASG name %s with err: %s\n", asgName, err.Error())
-	// 	return err
-	// }
-	//
-	// filters := replaceWhitespace(filterByTags)
-	//
-	// var tagsToMatch = []Tag{}
-	//
-	// if len(filters) == 0 {
-	// 	tagsToMatch = []Tag{{Key: "spot-enabled", Value: "true"}}
-	// }
-	//
-	// for _, tagWithValue := range strings.Split(filters, ",") {
-	// 	tag := splitTagAndValue(tagWithValue)
-	// 	if tag != nil {
-	// 		tagsToMatch = append(tagsToMatch, *tag)
-	// 	}
-	// }
-	//
-	// if len(tagsToMatch) == 0 {
-	// 	tagsToMatch = []Tag{{Key: "spot-enabled", Value: "true"}}
-	// }
-	//
-	// groupMatchesExpectedTags := isASGWithMatchingTags(asgGroupsOutput.AutoScalingGroups[0], tagsToMatch)
-	//
-	// if optInFilterMode != groupMatchesExpectedTags {
-	// 	logger.Printf("Skipping group %s because its tags, the currently "+
-	// 		"configured filtering mode (%s) and tag filters do not align\n",
-	// 		asgName, tagFilteringMode)
-	// 	return nil
-	// }
 
 	switch terminationNotificationAction {
 	case "detach":

--- a/core/spot_termination.go
+++ b/core/spot_termination.go
@@ -208,6 +208,11 @@ func (s *SpotTermination) asgHasTerminationLifecycleHook(autoScalingGroupName *s
 // Checks to see whether an instance is in an AutoSpotting ASG as defined by tags
 // If the ASG does not have the required tags, it is not an AutoSpotting ASG and should be left
 func (s *SpotTermination) isInAutoSpottingASG(instanceID *string, tagFilteringMode string, filterByTags string) bool {
+	if s.asSvc == nil {
+		logger.Println("AutoScaling service not defined. Please use NewSpotTermination()")
+		return false
+	}
+
 	var optInFilterMode = (tagFilteringMode != "opt-out")
 
 	asgName, err := s.getAsgName(instanceID)

--- a/core/spot_termination_test.go
+++ b/core/spot_termination_test.go
@@ -346,3 +346,31 @@ func TestExecuteAction(t *testing.T) {
 		})
 	}
 }
+
+// func TestIsInAutoSpottingASG(t *testing.T) {
+// 	instanceID := "dummyInstanceID"
+// 	tagFilteringMode := "opt-in"
+// 	filterByTags := ""
+//
+// 	tests := []struct {
+// 		name            string
+// 		spotTermination *SpotTermination
+// 		expected        bool
+// 	}{
+// 		{
+// 			name:            "When AutoScaling service is nil",
+// 			spotTermination: &SpotTermination{},
+// 			expected:        false,
+// 		},
+// 	}
+// 	for _, tc := range tests {
+// 		t.Run(tc.name, func(t *testing.T) {
+//
+// 			actual := tc.spotTermination.isInAutoSpottingASG(&instanceID, tagFilteringMode, filterByTags)
+//
+// 			if tc.expected != actual {
+// 				t.Errorf("isInAutoSpottingASG received for %s: %v expected %v", tc.name, actual, tc.expected)
+// 			}
+// 		})
+// 	}
+// }

--- a/core/spot_termination_test.go
+++ b/core/spot_termination_test.go
@@ -349,24 +349,42 @@ func TestExecuteAction(t *testing.T) {
 
 // func TestIsInAutoSpottingASG(t *testing.T) {
 // 	instanceID := "dummyInstanceID"
-// 	tagFilteringMode := "opt-in"
-// 	filterByTags := ""
+// 	dummyAsg := []*autoscaling.Group{
+// 		{AutoScalingGroupName: aws.String("dummyASGName")},
+// 	}
+// 	// tagFilteringMode := "opt-in"
+// 	// filterByTags := ""
 //
 // 	tests := []struct {
-// 		name            string
-// 		spotTermination *SpotTermination
-// 		expected        bool
+// 		name             string
+// 		spotTermination  *SpotTermination
+// 		tagFilteringMode string
+// 		filterByTags     string
+// 		expected         bool
 // 	}{
 // 		{
-// 			name:            "When AutoScaling service is nil",
-// 			spotTermination: &SpotTermination{},
-// 			expected:        false,
+// 			name:             "When AutoScaling service is nil",
+// 			spotTermination:  &SpotTermination{},
+// 			tagFilteringMode: "opt-in",
+// 			filterByTags:     "",
+// 			expected:         false,
+// 		},
+// 		{
+// 			name: "When there is no tags to filter from",
+// 			spotTermination: &SpotTermination{
+// 				asSvc: mockASG{dasgo: &autoscaling.DescribeAutoScalingGroupsOutput{
+// 					AutoScalingGroups: dummyAsg,
+// 				}},
+// 			},
+// 			tagFilteringMode: "opt-in",
+// 			filterByTags:     "",
+// 			expected:         false,
 // 		},
 // 	}
 // 	for _, tc := range tests {
 // 		t.Run(tc.name, func(t *testing.T) {
 //
-// 			actual := tc.spotTermination.isInAutoSpottingASG(&instanceID, tagFilteringMode, filterByTags)
+// 			actual := tc.spotTermination.isInAutoSpottingASG(&instanceID, tc.tagFilteringMode, tc.filterByTags)
 //
 // 			if tc.expected != actual {
 // 				t.Errorf("isInAutoSpottingASG received for %s: %v expected %v", tc.name, actual, tc.expected)


### PR DESCRIPTION
# Issue Type
- Feature Pull Request

## Summary

Should help #362

Uses the filter options set in AutoSpotting to be a bit more smarter about terminating instances.

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
