### PR TITLE
Fix `make archive` on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ archive: build                                               ## Create archive t
 	@cp -f cloudformation/stacks/AutoSpotting/template.yaml $(LOCAL_PATH)/template_build_$(BUILD).yaml
 	@zip -j $(LOCAL_PATH)/regional_stack_lambda.zip cloudformation/stacks/AutoSpotting/regional_stack_lambda.py
 	@cp -f cloudformation/stacks/AutoSpotting/regional_template.yaml $(LOCAL_PATH)/
-	@sed -i "s#lambda\.zip#lambda_build_$(BUILD).zip#" $(LOCAL_PATH)/template_build_$(BUILD).yaml
+	@sed -e "s#lambda\.zip#lambda_build_$(BUILD).zip#" $(LOCAL_PATH)/template_build_$(BUILD).yaml > $(LOCAL_PATH)/template_build_$(BUILD).yaml.new
+	@mv -- $(LOCAL_PATH)/template_build_$(BUILD).yaml.new $(LOCAL_PATH)/template_build_$(BUILD).yaml
 	@cp -f $(LOCAL_PATH)/lambda.zip $(LOCAL_PATH)/lambda_build_$(BUILD).zip
 	@cp -f $(LOCAL_PATH)/lambda.zip $(LOCAL_PATH)/lambda_build_$(SHA).zip
 	@cp -f $(LOCAL_PATH)/regional_stack_lambda.zip $(LOCAL_PATH)/regional_stack_lambda_build_$(BUILD).zip


### PR DESCRIPTION
The `-i` option is not specified in POSIX `sed`. As such, different implementations handle it differently.

See https://unix.stackexchange.com/questions/92895/how-can-i-achieve-portability-with-sed-i-in-place-editing

Fixes #377

# Issue Type

Bugfix Pull Request

## Summary

Fixes `mark archive` on macOS by using POSIX-compliant `sed` invocation.

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [x] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [x] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [x] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [x] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
