### PR TITLE
Support spot price buffer percentage of 0

### DIFF
--- a/core/autoscaling_configuration.go
+++ b/core/autoscaling_configuration.go
@@ -135,7 +135,7 @@ func (a *autoScalingGroup) loadSpotPriceBufferPercentage(tagValue *string) (floa
 	if err != nil {
 		logger.Printf("Error with ParseFloat: %s\n", err.Error())
 		return DefaultSpotPriceBufferPercentage, false
-	} else if spotPriceBufferPercentage <= 0 {
+	} else if spotPriceBufferPercentage < 0 {
 		logger.Printf("Ignoring out of range value : %f\n", spotPriceBufferPercentage)
 		return DefaultSpotPriceBufferPercentage, false
 	}

--- a/core/autoscaling_configuration_test.go
+++ b/core/autoscaling_configuration_test.go
@@ -31,6 +31,11 @@ func TestLoadSpotPriceBufferPercentage(t *testing.T) {
 			valueExpected:   10.0,
 			loadingExpected: false,
 		},
+		{
+			tagValue:        aws.String("0"),
+			valueExpected:   0.0,
+			loadingExpected: true,
+		},
 	}
 	for _, tt := range tests {
 		a := autoScalingGroup{Group: &autoscaling.Group{}}

--- a/core/instance.go
+++ b/core/instance.go
@@ -460,7 +460,8 @@ func (i *instance) getPricetoBid(
 	}
 
 	bufferPrice := math.Min(baseOnDemandPrice, currentSpotPrice*(1.0+i.region.conf.SpotPriceBufferPercentage/100.0))
-	logger.Println("Bidding buffer-based price", bufferPrice)
+	logger.Println("Bidding buffer-based price of", bufferPrice, "based on current spot price of", currentSpotPrice,
+		"and buffer percentage of", i.region.conf.SpotPriceBufferPercentage)
 	return bufferPrice
 }
 

--- a/core/instance_test.go
+++ b/core/instance_test.go
@@ -1135,6 +1135,13 @@ func TestGetPricetoBid(t *testing.T) {
 			policy:               "aggressive",
 			want:                 0.0464,
 		},
+		{
+			spotPercentage:       0.0,
+			currentSpotPrice:     0.0216,
+			currentOnDemandPrice: 0.0464,
+			policy:               "aggressive",
+			want:                 0.0216,
+		},
 	}
 	for _, tt := range tests {
 		cfg := &Config{


### PR DESCRIPTION
Fixes #380

# Issue Type

Bugfix Pull Request

## Summary

Bid at current spot price when spot_price_buffer_percentage is 0, instead of bidding at 10% above spot price.

See #380 for discussion.

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [x] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
