### PR TITLE
Move some logs to debug

### DIFF
--- a/core/connections.go
+++ b/core/connections.go
@@ -32,7 +32,7 @@ func (c *connections) setSession(region string) {
 
 func (c *connections) connect(region string) {
 
-	logger.Println("Creating Service connections in", region)
+	debug.Println("Creating service connections in", region)
 
 	if c.session == nil {
 		c.setSession(region)
@@ -48,5 +48,5 @@ func (c *connections) connect(region string) {
 
 	c.autoScaling, c.ec2, c.cloudFormation, c.region = <-asConn, <-ec2Conn, <-cloudformationConn, region
 
-	logger.Println("Created service connections in", region)
+	debug.Println("Created service connections in", region)
 }

--- a/core/region.go
+++ b/core/region.go
@@ -141,7 +141,7 @@ func splitTagAndValue(value string) *Tag {
 }
 
 func (r *region) processDescribeInstancesPage(page *ec2.DescribeInstancesOutput, lastPage bool) bool {
-	logger.Println("Processing page of DescribeInstancesPages for", r.name)
+	debug.Println("Processing page of DescribeInstancesPages for", r.name)
 	debug.Println(page)
 
 	if len(page.Reservations) > 0 &&
@@ -271,13 +271,13 @@ func (r *region) requestSpotPrices() error {
 		// spot market
 		price, err := strconv.ParseFloat(*priceInfo.SpotPrice, 64)
 		if err != nil {
-			logger.Println(r.name, "Instance type ", instType,
+			debug.Println(r.name, "Instance type ", instType,
 				"is not available on the spot market")
 			continue
 		}
 
 		if r.instanceTypeInformation[instType].pricing.spot == nil {
-			logger.Println(r.name, "Instance data missing for", instType, "in", az,
+			debug.Println(r.name, "Instance data missing for", instType, "in", az,
 				"skipping because this region is currently not supported")
 			continue
 		}
@@ -367,7 +367,7 @@ func (r *region) findMatchingASGsInPageOfResults(groups []*autoscaling.Group,
 		asgName := *group.AutoScalingGroupName
 
 		if group.MixedInstancesPolicy != nil {
-			logger.Printf("Skipping group %s because it's using a mixed instances policy",
+			debug.Printf("Skipping group %s because it's using a mixed instances policy",
 				asgName)
 			continue
 		}
@@ -377,14 +377,14 @@ func (r *region) findMatchingASGsInPageOfResults(groups []*autoscaling.Group,
 		// expression. The goal is to add the matching ASGs when running in opt-in
 		// mode and the other way round.
 		if optInFilterMode != groupMatchesExpectedTags {
-			logger.Printf("Skipping group %s because its tags, the currently "+
+			debug.Printf("Skipping group %s because its tags, the currently "+
 				"configured filtering mode (%s) and tag filters do not align\n",
 				asgName, r.conf.TagFilteringMode)
 			continue
 		}
 
 		if stackName := getTagValueFromASGWithMatchingTag(group, tagCloudFormationStackName); stackName != nil {
-			logger.Println("Stack: ", *stackName)
+			debug.Println("Stack: ", *stackName)
 			if status, updating := r.isStackUpdating(stackName); updating {
 				logger.Printf("Skipping group %s because stack %s is in state %s\n",
 					asgName, *stackName, status)
@@ -413,7 +413,7 @@ func (r *region) scanForEnabledAutoScalingGroups() {
 		&autoscaling.DescribeAutoScalingGroupsInput{},
 		func(page *autoscaling.DescribeAutoScalingGroupsOutput, lastPage bool) bool {
 			pageNum++
-			logger.Println("Processing page", pageNum, "of DescribeAutoScalingGroupsPages for", r.name)
+			debug.Println("Processing page", pageNum, "of DescribeAutoScalingGroupsPages for", r.name)
 			matchingAsgs := r.findMatchingASGsInPageOfResults(page.AutoScalingGroups, r.tagsToFilterASGsBy)
 			r.enabledASGs = append(r.enabledASGs, matchingAsgs...)
 			return true


### PR DESCRIPTION
I don't think these logs decrease the signal-to-noise ratio for everyday use, although others may disagree.

I'm happy to break this up into smaller PRs if that's desired, and I'm happy to remove anything from this PR that you think is worth keeping.

Fixes #382

# Issue Type

Feature Pull Request

## Summary

Move some logs to debug.

In my tests, I'm seeing lines logged go from > 500 to < 100 for invocations where AutoSpotting doesn't terminate or launch any instances. 

## Code contribution checklist

1. [x] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
