### PR TITLE
Ignore terminating spot instances that don't belong to AutoSpotting

### DIFF
--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -151,7 +151,8 @@ type mockASG struct {
 	dto *autoscaling.DescribeTagsOutput
 
 	// Describe AutoScaling Group
-	dasgo *autoscaling.DescribeAutoScalingGroupsOutput
+	dasgo   *autoscaling.DescribeAutoScalingGroupsOutput
+	dasgerr error
 
 	// Describe AutoScalingInstances
 	dasio   *autoscaling.DescribeAutoScalingInstancesOutput
@@ -185,6 +186,10 @@ func (m mockASG) UpdateAutoScalingGroup(*autoscaling.UpdateAutoScalingGroupInput
 func (m mockASG) DescribeTagsPages(input *autoscaling.DescribeTagsInput, function func(*autoscaling.DescribeTagsOutput, bool) bool) error {
 	function(m.dto, true)
 	return nil
+}
+
+func (m mockASG) DescribeAutoScalingGroups(input *autoscaling.DescribeAutoScalingGroupsInput) (*autoscaling.DescribeAutoScalingGroupsOutput, error) {
+	return m.dasgo, m.dasgerr
 }
 
 func (m mockASG) DescribeAutoScalingGroupsPages(input *autoscaling.DescribeAutoScalingGroupsInput, function func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool) error {

--- a/core/spot_termination.go
+++ b/core/spot_termination.go
@@ -6,6 +6,7 @@ package autospotting
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go/aws"
@@ -208,4 +209,52 @@ func (s *SpotTermination) asgHasTerminationLifecycleHook(autoScalingGroupName *s
 	}
 
 	return hasHook
+}
+
+// IsInAutoSpottingASG checks to see whether an instance is in an AutoSpotting ASG as defined by its tags.
+// If the ASG does not have the required tags, it is not an AutoSpotting ASG and should be left alone.
+func (s *SpotTermination) IsInAutoSpottingASG(instanceID *string, tagFilteringMode string, filterByTags string) bool {
+	var optInFilterMode = (tagFilteringMode != "opt-out")
+
+	asgName, err := s.getAsgName(instanceID)
+
+	if err != nil {
+		logger.Printf("Failed get ASG name for %s with err: %s\n", *instanceID, err.Error())
+		return false
+	} else if asgName == "" {
+		logger.Println("Instance", instanceID, "is not in an autoscaling group")
+		return false
+	}
+
+	asgGroupsOutput, err := s.asSvc.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{
+			&asgName,
+		},
+	})
+
+	if err != nil {
+		logger.Printf("Failed to get ASG using ASG name %s with err: %s\n", asgName, err.Error())
+		return false
+	}
+
+	filters := replaceWhitespace(filterByTags)
+
+	var tagsToMatch = []Tag{}
+
+	for _, tagWithValue := range strings.Split(filters, ",") {
+		tag := splitTagAndValue(tagWithValue)
+		if tag != nil {
+			tagsToMatch = append(tagsToMatch, *tag)
+		}
+	}
+
+	isInASG := optInFilterMode == isASGWithMatchingTags(asgGroupsOutput.AutoScalingGroups[0], tagsToMatch)
+
+	if !isInASG {
+		logger.Printf("Skipping group %s because its tags, the currently "+
+			"configured filtering mode (%s) and tag filters do not align\n",
+			asgName, tagFilteringMode)
+	}
+
+	return isInASG
 }


### PR DESCRIPTION
This is a reworking of #363 against `master`. 

Since this fixes a fairly serious issues for those running AutoSpotting in multi-tenant environments, I think it makes sense to merge this first and then tackle remaining issues that are preventing #354 from being merged. 

Credit for original code goes to @cfarrend.

Fixes #362
Closes #363
Closes #390

# Issue Type

<!--
Pick one below and delete the others.

Also feel free to delete these comments for brevity once they were fully
acknowledged.
-->

- Bugfix Pull Request

## Summary

<!--
Describe the change, including rationale and design decisions, and use a brief
but descriptive PR title.

Please include "Fixes #nnn" here or in your commit message in order to
link to an issue in which you describe the addressed problem in more detail.

If you want to address more issues do it in different pull requests instead of a
single big one, it will speed up the review process considerably.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [x] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
