### PR TITLE
Make loadLaunchConfiguration return a launchConfiguration

### DIFF
--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -25,16 +25,16 @@ type autoScalingGroup struct {
 	config              AutoScalingConfig
 }
 
-func (a *autoScalingGroup) loadLaunchConfiguration() error {
+func (a *autoScalingGroup) loadLaunchConfiguration() (*launchConfiguration, error) {
 	//already done
 	if a.launchConfiguration != nil {
-		return nil
+		return a.launchConfiguration, nil
 	}
 
 	lcName := a.LaunchConfigurationName
 
 	if lcName == nil {
-		return errors.New("missing launch configuration")
+		return nil, errors.New("missing launch configuration")
 	}
 
 	svc := a.region.services.autoScaling
@@ -46,13 +46,13 @@ func (a *autoScalingGroup) loadLaunchConfiguration() error {
 
 	if err != nil {
 		logger.Println(err.Error())
-		return err
+		return nil, err
 	}
 
 	a.launchConfiguration = &launchConfiguration{
 		LaunchConfiguration: resp.LaunchConfigurations[0],
 	}
-	return nil
+	return a.launchConfiguration, nil
 }
 
 func (a *autoScalingGroup) needReplaceOnDemandInstances() bool {

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -34,7 +34,8 @@ func (a *autoScalingGroup) loadLaunchConfiguration() (*launchConfiguration, erro
 	lcName := a.LaunchConfigurationName
 
 	if lcName == nil {
-		return nil, errors.New("missing launch configuration")
+		// ASG does not have launch configuration
+		return nil, nil
 	}
 
 	svc := a.region.services.autoScaling
@@ -158,7 +159,10 @@ func (a *autoScalingGroup) process() {
 			return
 		}
 
-		a.loadLaunchConfiguration()
+		if _, err := a.loadLaunchConfiguration(); err != nil {
+			logger.Printf("Could not launch configuration: %s", err)
+		}
+
 		err := onDemandInstance.launchSpotReplacement()
 		if err != nil {
 			logger.Printf("Could not launch cheapest spot instance: %s", err)

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -796,7 +796,7 @@ func TestLoadLaunchConfiguration(t *testing.T) {
 						dlcerr: nil},
 				},
 			},
-			expectedErr: errors.New("missing launch configuration"),
+			expectedErr: nil,
 			expectedLC:  nil,
 		},
 		{name: "no err during get launch configuration",

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -845,8 +845,7 @@ func TestLoadLaunchConfiguration(t *testing.T) {
 					LaunchConfigurationName: tt.nameLC,
 				},
 			}
-			err := a.loadLaunchConfiguration()
-			lc := a.launchConfiguration
+			lc, err := a.loadLaunchConfiguration()
 
 			if !reflect.DeepEqual(tt.expectedErr, err) {
 				t.Errorf("loadLaunchConfiguration received error status: %+v expected %+v",
@@ -856,6 +855,11 @@ func TestLoadLaunchConfiguration(t *testing.T) {
 			if !reflect.DeepEqual(tt.expectedLC, lc) {
 				t.Errorf("loadLaunchConfiguration received: %+v expected %+v",
 					lc, tt.expectedLC)
+			}
+
+			if lc != a.launchConfiguration {
+				t.Errorf("loadLaunchConfiguration returned %+v but set member field launchConfiguration to %+v",
+					lc, a.launchConfiguration)
 			}
 		})
 	}


### PR DESCRIPTION
It previously mutated the receiver, but did not return the loaded launchConfiguration.

This was pulled out of #354, with some additional error handling.

# Issue Type

<!--
Pick one below and delete the others.

Also feel free to delete these comments for brevity once they were fully
acknowledged.
-->

Feature Pull Request

## Summary

Pulling out a small part of the big event-based-instance-replacement work. This part seems fairly inconsequential, but need to start somewhere :) 
<!--
Describe the change, including rationale and design decisions, and use a brief
but descriptive PR title.

Please include "Fixes #nnn" here or in your commit message in order to
link to an issue in which you describe the addressed problem in more detail.

If you want to address more issues do it in different pull requests instead of a
single big one, it will speed up the review process considerably.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [x] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
