### PR TITLE
Rename travisci make targets to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
     # encrypted coveralls secret token, defined as the COVERALLS_TOKEN environment variable
     secure: E0H+b3i171uG8e/w6AVV9HDCCcoReTNlk2+YSENFYmnzxBmvQOo2YwI1jtBRgktG51yZZCzUJZnc0bkaghRT6nS6H8gVUN5GuZjMXdEwY3r+2Zqka6sS1ym+PK6JEA1bRjtX2iQFtk2V68gzUNvjKj8YB2zVJmX6St7tcQ9lBcluQ0xEFu7MZMknYrl9W2NnAhajt27D50uUELtSo3n61TEXXIvFRQyjHCMpGmqeZcXYtiSZAyZjraTsZr9/dngOSw0iExXDDa7cYPHHmmre+3aQUJ9AzotgB+C3+SJ+zOaOGPvVc4PS/G2Wj4siQ1Yv3nl9pvGgxeKtZgVQ92KN9ngdVtRs+XnwMC/x9VJN8vHHgI+coETZ9lhwhjeS8yFIXdBaktXz014ZVrVVpSB+BzoW4r6x/MlmZh0muJNME5OGFXbR0qFaaUB9WdQCst+MhVvSKiZ3Slmck4/3UcyAsuePj0sF1Z/yv9YJR84NTEUdif/PQnBDC1ulhXAIhZ+gm7ZOMZXRW9U7YZlHnFpBg8KoVETlnkT6AjKZ5jy+gz4CgisN2H7OuyjVQm5kIEXPo8ORJqYHPM3tu9HVsCHb6Pm+y9pec/1YXSKtmFbJiYeAmbz3Lp8vVUX5tOo24o0hCyU7qA/ypCUxRoHrHHC+c9u8nQDWGcQBD0azp+dcy2s=
 script:
-- make travisci-docker
+- make ci-docker
 after_success:
 - curl --request POST "https://goreportcard.com/checks" --data "repo=github.com/AutoSpotting/AutoSpotting"
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -107,21 +107,21 @@ html-cover: test                                             ## Display coverage
 	@go tool cover -html=$(COVER_PROFILE)
 .PHONY: html-cover
 
-travisci-cover: html-cover                                   ## Test & generate coverage in the TravisCI format, fails unless executed from TravisCI
+ci-cover: html-cover                                         ## Test & generate coverage in the TravisCI format, fails unless executed from TravisCI
 ifdef COVERALLS_TOKEN
 	@goveralls -coverprofile=$(COVER_PROFILE) -service=travis-ci -repotoken=$(COVERALLS_TOKEN)
 endif
-.PHONY: travisci-cover
+.PHONY: ci-cover
 
-travisci-checks: fmt-check vet-check lint                    ## Pass fmt / vet & lint format
-.PHONY: travisci-checks
+ci-checks: fmt-check vet-check lint                          ## Pass fmt / vet & lint format
+.PHONY: ci-checks
 
-travisci: archive travisci-checks travisci-cover             ## Executes inside the TravisCI Docker builder
-.PHONY: travisci
+ci: archive ci-checks ci-cover                               ## Executes inside the CI Docker builder
+.PHONY: ci
 
-travisci-docker:                                             ## Executed by TravisCI
+ci-docker:                                                   ## Executed by CI
 	@docker-compose up --build --abort-on-container-exit --exit-code-from autospotting
-.PHONY: travisci-docker
+.PHONY: ci-docker
 
 help:                                                        ## Show this help
 	@printf "Rules:\n"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
         - TRAVIS_BUILD_NUMBER
         entrypoint:
           - make
-          - travisci
+          - ci
         volumes:
           - type: bind
             source: ./build


### PR DESCRIPTION
These targets are pretty much generic and do not need to run in TravisCI. 

I specifically have a use case where I am running some of them in a different CI provider, so invoking `make travisci` is awkward. And who knows, maybe in the future we'll all be using GitHub actions 😉  

# Issue Type

<!--
Pick one below and delete the others.

Also feel free to delete these comments for brevity once they were fully
acknowledged.
-->

Feature Pull Request

## Summary
Rename the following make targets:
- `travisci-cover` -> `ci-cover`
- `travisci-checks` -> `ci-checks`
- `travisci` -> `ci`
- `travisci-docker` -> `ci-docker`


<!--
Describe the change, including rationale and design decisions, and use a brief
but descriptive PR title.

Please include "Fixes #nnn" here or in your commit message in order to
link to an issue in which you describe the addressed problem in more detail.

If you want to address more issues do it in different pull requests instead of a
single big one, it will speed up the review process considerably.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [x] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
