### PR TITLE
Move TestMain from spot_price_test.go to main_test.go

### DIFF
--- a/core/main.go
+++ b/core/main.go
@@ -68,10 +68,6 @@ func addDefaultFilter(cfg *Config) {
 	}
 }
 
-func disableLogging() {
-	setupLogging(&Config{LogFile: ioutil.Discard})
-}
-
 func setupLogging(cfg *Config) {
 	logger = log.New(cfg.LogFile, "", cfg.LogFlag)
 

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -5,12 +5,31 @@ package autospotting
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
+
+func TestMain(m *testing.M) {
+	var logOutput io.Writer
+
+	if os.Getenv("AUTOSPOTTING_DEBUG") == "true" {
+		logOutput = os.Stdout
+	} else {
+		logOutput = ioutil.Discard
+	}
+
+	logger = log.New(logOutput, "", 0)
+	debug = log.New(logOutput, "", 0)
+
+	os.Exit(m.Run())
+}
 
 func Test_getRegions(t *testing.T) {
 

--- a/core/spot_price_test.go
+++ b/core/spot_price_test.go
@@ -5,18 +5,12 @@ package autospotting
 
 import (
 	"errors"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
-
-func TestMain(m *testing.M) {
-	disableLogging()
-	os.Exit(m.Run())
-}
 
 func Test_fetch(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
This change was pulled from #354.

I actually think TestMain needs to be rethought in light of issues like https://github.com/AutoSpotting/AutoSpotting/issues/358 (real code doesn't always initialize globals, so neither should tests), but punting on that until the larger changes from #354 are done. 



## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [x] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
