### PR TITLE
Use paginated version of DescribeSpotPriceHistory

### DIFF
--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -28,9 +28,11 @@ func CheckErrors(t *testing.T, err error, expected error) {
 type mockEC2 struct {
 	ec2iface.EC2API
 
-	// Describe Spot Price History
-	dspho   *ec2.DescribeSpotPriceHistoryOutput
-	dspherr error
+	// DescribeSpotPriceHistoryPages output
+	dsphpo []*ec2.DescribeSpotPriceHistoryOutput
+
+	// DescribeSpotPriceHistoryPages error
+	dsphperr error
 
 	// DescribeInstancesOutput
 	dio *ec2.DescribeInstancesOutput
@@ -59,13 +61,16 @@ type mockEC2 struct {
 	dltverr error
 }
 
-func (m mockEC2) DescribeSpotPriceHistory(in *ec2.DescribeSpotPriceHistoryInput) (*ec2.DescribeSpotPriceHistoryOutput, error) {
-	return m.dspho, m.dspherr
+func (m mockEC2) DescribeSpotPriceHistoryPages(in *ec2.DescribeSpotPriceHistoryInput, f func(*ec2.DescribeSpotPriceHistoryOutput, bool) bool) error {
+	for i, page := range m.dsphpo {
+		f(page, i == len(m.dsphpo)-1)
+	}
+	return m.dsphperr
 }
 
 func (m mockEC2) DescribeInstancesPages(in *ec2.DescribeInstancesInput, f func(*ec2.DescribeInstancesOutput, bool) bool) error {
 	f(m.dio, true)
-	return nil
+	return m.diperr
 }
 
 func (m mockEC2) DescribeInstanceAttribute(in *ec2.DescribeInstanceAttributeInput) (*ec2.DescribeInstanceAttributeOutput, error) {

--- a/core/region_test.go
+++ b/core/region_test.go
@@ -197,10 +197,11 @@ func TestOnDemandPriceMultiplier(t *testing.T) {
 			conf: cfg,
 			services: connections{
 				ec2: mockEC2{
-					dspho: &ec2.DescribeSpotPriceHistoryOutput{
-						SpotPriceHistory: []*ec2.SpotPrice{},
+					dsphpo: []*ec2.DescribeSpotPriceHistoryOutput{
+						{
+							SpotPriceHistory: []*ec2.SpotPrice{},
+						},
 					},
-					dspherr: nil,
 				},
 			}}
 		r.determineInstanceTypeInformation(cfg)

--- a/core/spot_price.go
+++ b/core/spot_price.go
@@ -34,14 +34,18 @@ func (s *spotPrices) fetch(product string,
 		InstanceTypes:    instanceTypes,
 	}
 
-	resp, err := ec2Conn.DescribeSpotPriceHistory(params)
+	data := []*ec2.SpotPrice{}
+	err := ec2Conn.DescribeSpotPriceHistoryPages(params, func(page *ec2.DescribeSpotPriceHistoryOutput, lastPage bool) bool {
+		data = append(data, page.SpotPriceHistory...)
+		return true
+	})
 
 	if err != nil {
 		logger.Println(s.conn.region, "Failed requesting spot prices:", err.Error())
 		return err
 	}
 
-	s.data = resp.SpotPriceHistory
+	s.data = data
 
 	return nil
 }

--- a/core/spot_price_test.go
+++ b/core/spot_price_test.go
@@ -29,10 +29,12 @@ func Test_fetch(t *testing.T) {
 				data: []*ec2.SpotPrice{},
 				conn: connections{
 					ec2: mockEC2{
-						dspho: &ec2.DescribeSpotPriceHistoryOutput{
-							SpotPriceHistory: []*ec2.SpotPrice{},
+						dsphpo: []*ec2.DescribeSpotPriceHistoryOutput{
+							{
+								SpotPriceHistory: []*ec2.SpotPrice{},
+							},
 						},
-						dspherr: errors.New("error"),
+						dsphperr: errors.New("error"),
 					},
 				},
 			},
@@ -45,9 +47,11 @@ func Test_fetch(t *testing.T) {
 				data: []*ec2.SpotPrice{},
 				conn: connections{
 					ec2: mockEC2{
-						dspho: &ec2.DescribeSpotPriceHistoryOutput{
-							SpotPriceHistory: []*ec2.SpotPrice{
-								{SpotPrice: aws.String("1")},
+						dsphpo: []*ec2.DescribeSpotPriceHistoryOutput{
+							{
+								SpotPriceHistory: []*ec2.SpotPrice{
+									{SpotPrice: aws.String("1")},
+								},
 							},
 						},
 					},
@@ -57,6 +61,33 @@ func Test_fetch(t *testing.T) {
 				{SpotPrice: aws.String("1")},
 			},
 			err: errors.New(""),
+		},
+		{
+			name: "paginated output",
+			config: &spotPrices{
+				data: []*ec2.SpotPrice{},
+				conn: connections{
+					ec2: mockEC2{
+						dsphpo: []*ec2.DescribeSpotPriceHistoryOutput{
+							{
+								SpotPriceHistory: []*ec2.SpotPrice{
+									{SpotPrice: aws.String("1")},
+								},
+							},
+							{
+								SpotPriceHistory: []*ec2.SpotPrice{
+									{SpotPrice: aws.String("2")},
+								},
+							},
+						},
+						dsphperr: nil,
+					},
+				},
+			},
+			data: []*ec2.SpotPrice{
+				{SpotPrice: aws.String("1")},
+				{SpotPrice: aws.String("2")},
+			},
 		},
 	}
 


### PR DESCRIPTION
This may help with #376.

# Issue Type

<!--
Pick one below and delete the others.

Also feel free to delete these comments for brevity once they were fully
acknowledged.
-->

- Bugfix Pull Request

## Summary

Use `DescribeSpotPriceHistoryPages` instead of `DescribeSpotPriceHistory`.

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [x] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
