### PR TITLE
Added spot premium

### DIFF
--- a/START.md
+++ b/START.md
@@ -298,6 +298,10 @@ Usage of ./AutoSpotting:
   -spot_product_description="Linux/UNIX (Amazon VPC)":
         The Spot Product or operating system to use when looking up spot price history in the market.
         Valid choices: Linux/UNIX | SUSE Linux | Windows | Linux/UNIX (Amazon VPC) | SUSE Linux (Amazon VPC) | Windows (Amazon VPC)
+  -spot_product_premium=0:
+        The Product Premium to apply to the on demand price to improve spot
+        selection and savings calculations when using a premium instance type
+        such as RHEL.
 
   -tag_filters=[{spot-enabled true}]: Set of tags to filter the ASGs on.  Default is -tag_filters 'spot-enabled=true'
         Example: ./AutoSpotting -tag_filters 'spot-enabled=true,Environment=dev,Team=vision'

--- a/cloudformation/stacks/AutoSpotting/template.yaml
+++ b/cloudformation/stacks/AutoSpotting/template.yaml
@@ -219,13 +219,21 @@
         - "Linux/UNIX (Amazon VPC)"
         - "SUSE Linux (Amazon VPC)"
         - "Windows (Amazon VPC)"
+        - "Red Hat Enterprise Linux"
       Default: "Linux/UNIX (Amazon VPC)"
       Description: >
         "The Spot Product or operating system to use when looking up spot price
         history in the market. Valid choices: 'Linux/UNIX | SUSE Linux | Windows
         | Linux/UNIX (Amazon VPC) | SUSE Linux (Amazon VPC) | Windows (Amazon
-        VPC)'"
+        VPC) | Red Hat Enterprise Linux'"
       Type: "String"
+    SpotProductPremium:
+      Default: 0.0
+      Description: >
+        "The Product Premium to apply to the on demand price to improve spot
+        selection and savings calculations when using a premium instance type
+        such as RHEL."
+      Type: "Number"
     StackSetsMainRegion:
       Default: "us-east-1"
       Description: >
@@ -303,6 +311,12 @@
       Value:
         Fn::GetAtt:
           - "LambdaRegionalExecutionRole"
+          - "Arn"
+    LambdaExecutionRoleARN:
+      Condition: "StackSetsIsMain"
+      Value:
+        Fn::GetAtt:
+          - "LambdaExecutionRole"
           - "Arn"
   Resources:
     AutoSpotTeminationEventRule:
@@ -419,6 +433,8 @@
               Ref: "SpotPricePercentageBuffer"
             SPOT_PRODUCT_DESCRIPTION:
               Ref: "SpotProductDescription"
+            SPOT_PRODUCT_PREMIUM:
+              Ref: "SpotProductPremium"
             TAG_FILTERING_MODE:
               Ref: "TagFilteringMode"
             TAG_FILTERS:

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -95,7 +95,7 @@ func (a *autoScalingGroup) allInstancesRunning() bool {
 func (a *autoScalingGroup) calculateHourlySavings() float64 {
 	var savings float64
 	for i := range a.instances.instances() {
-		savings += i.typeInfo.pricing.onDemand - i.price
+		savings += (i.typeInfo.pricing.onDemand + i.typeInfo.pricing.premium) - i.price
 	}
 	return savings
 }
@@ -212,7 +212,7 @@ func (a *autoScalingGroup) scanInstances() instances {
 		if i.isSpot() {
 			i.price = i.typeInfo.pricing.spot[*i.Placement.AvailabilityZone]
 		} else {
-			i.price = i.typeInfo.pricing.onDemand
+			i.price = i.typeInfo.pricing.onDemand + i.typeInfo.pricing.premium
 		}
 
 		a.instances.add(i)

--- a/core/autoscaling_configuration.go
+++ b/core/autoscaling_configuration.go
@@ -47,6 +47,10 @@ const (
 	// to use when looking up spot price history in the market.
 	DefaultSpotProductDescription = "Linux/UNIX (Amazon VPC)"
 
+	// DefaultSpotProductPremium stores the default value to add to the
+	// on demand price for premium instance types.
+	DefaultSpotProductPremium = 0.0
+
 	// DefaultMinOnDemandValue stores the default on-demand capacity to be kept
 	// running in a group managed by autospotting.
 	DefaultMinOnDemandValue = 0
@@ -93,6 +97,7 @@ type AutoScalingConfig struct {
 	SpotPriceBufferPercentage float64
 
 	SpotProductDescription string
+	SpotProductPremium     float64
 
 	BiddingPolicy string
 

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -929,6 +929,7 @@ func TestScanInstances(t *testing.T) {
 							typeInfo: instanceTypeInformation{
 								pricing: prices{
 									onDemand: 0.5,
+									premium:  0.0,
 									spot: map[string]float64{
 										"az-1": 0.1,
 										"az-2": 0.2,
@@ -947,6 +948,7 @@ func TestScanInstances(t *testing.T) {
 							typeInfo: instanceTypeInformation{
 								pricing: prices{
 									onDemand: 0.8,
+									premium:  0.0,
 									spot: map[string]float64{
 										"az-1": 0.4,
 										"az-2": 0.5,
@@ -3233,6 +3235,31 @@ func Test_autoScalingGroup_calculateHourlySavings(t *testing.T) {
 					},
 				}),
 			want: 0.9,
+		},
+		{
+			name: "premium-instance",
+			instances: makeInstancesWithCatalog(
+				instanceMap{
+					"ondemand-1": {
+						price: 1.6,
+						typeInfo: instanceTypeInformation{
+							pricing: prices{
+								onDemand: 1.0,
+								premium:  0.6,
+							},
+						},
+					},
+					"spot-1": {
+						price: 0.1,
+						typeInfo: instanceTypeInformation{
+							pricing: prices{
+								onDemand: 1.0,
+								premium:  0.6,
+							},
+						},
+					},
+				}),
+			want: 1.5,
 		},
 	}
 	for _, tt := range tests {

--- a/core/config.go
+++ b/core/config.go
@@ -157,7 +157,10 @@ func ParseConfig(conf *Config) {
 	flagSet.StringVar(&conf.SpotProductDescription, "spot_product_description", DefaultSpotProductDescription,
 		"\n\tThe Spot Product to use when looking up spot price history in the market.\n"+
 			"\tValid choices: Linux/UNIX | SUSE Linux | Windows | Linux/UNIX (Amazon VPC) | \n"+
-			"\tSUSE Linux (Amazon VPC) | Windows (Amazon VPC)\n\tDefault value: "+DefaultSpotProductDescription+"\n")
+			"\tSUSE Linux (Amazon VPC) | Windows (Amazon VPC) | Red Hat Enterprise Linux\n\tDefault value: "+DefaultSpotProductDescription+"\n")
+	flagSet.Float64Var(&conf.SpotProductPremium, "spot_product_premium", DefaultSpotProductPremium,
+		"\n\tThe Product Premium to apply to the on demand price to improve spot selection and savings calculations\n"+
+			"\twhen using a premium instance type such as RHEL.")
 	flagSet.StringVar(&conf.TagFilteringMode, "tag_filtering_mode", "opt-in", "\n\tControls the behavior of the tag_filters option.\n"+
 		"\tValid choices: opt-in | opt-out\n\tDefault value: 'opt-in'\n\tExample: ./AutoSpotting --tag_filtering_mode opt-out\n")
 	flagSet.StringVar(&conf.FilterByTags, "tag_filters", "", "\n\tSet of tags to filter the ASGs on.\n"+

--- a/core/region.go
+++ b/core/region.go
@@ -45,6 +45,7 @@ type prices struct {
 	onDemand     float64
 	spot         spotPriceMap
 	ebsSurcharge float64
+	premium      float64
 }
 
 // The key in this map is the availavility zone
@@ -209,6 +210,7 @@ func (r *region) determineInstanceTypeInformation(cfg *Config) {
 		price.onDemand = it.Pricing[r.name].Linux.OnDemand * cfg.OnDemandPriceMultiplier
 		price.spot = make(spotPriceMap)
 		price.ebsSurcharge = it.Pricing[r.name].EBSSurcharge
+		price.premium = r.conf.SpotProductPremium
 
 		// if at this point the instance price is still zero, then that
 		// particular instance type doesn't even exist in the current


### PR DESCRIPTION
# Issue Type

- Feature Pull Request

## Summary

Currently when using a premium OS such as RHEL the on demand price of any instance is taken from the standard linux version of the instance type and as such doesn't take into account the extra fees paid for premium instances. Further to this the spot price is calculated using the spot product description which when entered as "Red Had Enterprise Linux" gives a spot price which may be greater than the on demand price for standard linux instances, especially on smaller instances and so does not replace the on demand instance as it thinks there are no savings to be made.

This change looks to address the issue above by allowing a premium value to be set, for example 0.06 for RHEL, so that this can be added to the on demand price for a standard linux OS to giving an improved way to calculate savings and also whether a premium instance can be actually be replaced.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->

## Code contribution checklist

1. [x] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [x] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [x] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
