### PR TITLE
Update how bid price is calculated for premium instances

### DIFF
--- a/core/instance_test.go
+++ b/core/instance_test.go
@@ -1104,6 +1104,7 @@ func TestGetPricetoBid(t *testing.T) {
 		spotPercentage       float64
 		currentSpotPrice     float64
 		currentOnDemandPrice float64
+		spotPremium          float64
 		policy               string
 		want                 float64
 	}{
@@ -1111,6 +1112,7 @@ func TestGetPricetoBid(t *testing.T) {
 			spotPercentage:       50.0,
 			currentSpotPrice:     0.0216,
 			currentOnDemandPrice: 0.0464,
+			spotPremium:          0.0,
 			policy:               "aggressive",
 			want:                 0.0324,
 		},
@@ -1118,6 +1120,7 @@ func TestGetPricetoBid(t *testing.T) {
 			spotPercentage:       79.0,
 			currentSpotPrice:     0.0216,
 			currentOnDemandPrice: 0.0464,
+			spotPremium:          0.0,
 			policy:               "aggressive",
 			want:                 0.038664,
 		},
@@ -1125,6 +1128,7 @@ func TestGetPricetoBid(t *testing.T) {
 			spotPercentage:       79.0,
 			currentSpotPrice:     0.0216,
 			currentOnDemandPrice: 0.0464,
+			spotPremium:          0.0,
 			policy:               "normal",
 			want:                 0.0464,
 		},
@@ -1132,6 +1136,7 @@ func TestGetPricetoBid(t *testing.T) {
 			spotPercentage:       200.0,
 			currentSpotPrice:     0.0216,
 			currentOnDemandPrice: 0.0464,
+			spotPremium:          0.0,
 			policy:               "aggressive",
 			want:                 0.0464,
 		},
@@ -1139,8 +1144,17 @@ func TestGetPricetoBid(t *testing.T) {
 			spotPercentage:       0.0,
 			currentSpotPrice:     0.0216,
 			currentOnDemandPrice: 0.0464,
+			spotPremium:          0.0,
 			policy:               "aggressive",
 			want:                 0.0216,
+		},
+		{
+			spotPercentage:       50.0,
+			currentSpotPrice:     0.0816,
+			currentOnDemandPrice: 0.1064,
+			spotPremium:          0.06,
+			policy:               "aggressive",
+			want:                 0.0924,
 		},
 	}
 	for _, tt := range tests {
@@ -1161,7 +1175,8 @@ func TestGetPricetoBid(t *testing.T) {
 
 		currentSpotPrice := tt.currentSpotPrice
 		currentOnDemandPrice := tt.currentOnDemandPrice
-		actualPrice := i.getPricetoBid(currentOnDemandPrice, currentSpotPrice)
+		currentSpotPremium := tt.spotPremium
+		actualPrice := i.getPricetoBid(currentOnDemandPrice, currentSpotPrice, currentSpotPremium)
 		if math.Abs(actualPrice-tt.want) > 0.000001 {
 			t.Errorf("percentage = %.2f, policy = %s, expected price = %.5f, want %.5f, currentSpotPrice = %.5f",
 				tt.spotPercentage, tt.policy, actualPrice, tt.want, currentSpotPrice)


### PR DESCRIPTION
# Issue Type

- Bugfix Pull Request

## Summary

A bug fix for PR #423, currently when calculating the bid price for premium instances, using the aggressive policy, the premium is included when calculating the buffer and as such this adds on a buffer for the premium which should be fixed.

For example

A standard instance

ondemand price = 0.1
spot price = 0.05
premium = 0.0
buffer = 50%

would give a bid price of 0.075, which would be lower than the on demand price.

A premium instance

ondemand price = 0.16
spot price = 0.11
premium = 0.06
buffer = 50%

would give a bid price of 0.165, which would be higher than the on demand price.

A premium instance after this fix

ondemand price = 0.16
spot price = 0.11
premium = 0.06
buffer = 50%

would give a bid price of 0.135, which would be lower than the on demand price.

## Code contribution checklist

1. [x] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [x] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
