### PR TITLE
Use the larger of min-OD-instances and (min-OD-percent * current)

### DIFF
--- a/core/autoscaling_configuration_test.go
+++ b/core/autoscaling_configuration_test.go
@@ -350,33 +350,6 @@ func TestLoadConfOnDemand(t *testing.T) {
 			numberExpected:  1,
 			loadingExpected: true,
 		},
-		{name: "Number has priority on percentage value",
-			asgTags: []*autoscaling.TagDescription{
-				{
-					Key:   aws.String("Name"),
-					Value: aws.String("asg-test"),
-				},
-				{
-					Key:   aws.String(OnDemandPercentageTag),
-					Value: aws.String("75"),
-				},
-				{
-					Key:   aws.String(OnDemandNumberLong),
-					Value: aws.String("2"),
-				},
-			},
-			asgInstances: makeInstancesWithCatalog(
-				instanceMap{
-					"id-1": {},
-					"id-2": {},
-					"id-3": {},
-					"id-4": {},
-				},
-			),
-			maxSize:         aws.Int64(10),
-			numberExpected:  2,
-			loadingExpected: true,
-		},
 		{name: "Number is invalid so percentage value is used",
 			asgTags: []*autoscaling.TagDescription{
 				{
@@ -423,6 +396,64 @@ func TestLoadConfOnDemand(t *testing.T) {
 			asgInstances:    makeInstances(),
 			numberExpected:  DefaultMinOnDemandValue,
 			loadingExpected: false,
+		},
+		{name: "Number lower than percentage and both valid so take the percentage",
+			asgTags: []*autoscaling.TagDescription{
+				{
+					Key:   aws.String("Name"),
+					Value: aws.String("asg-test"),
+				},
+				{
+					Key:   aws.String(OnDemandPercentageTag),
+					Value: aws.String("75"),
+				},
+				{
+					Key:   aws.String(OnDemandNumberLong),
+					Value: aws.String("2"),
+				},
+			},
+			asgInstances: makeInstancesWithCatalog(
+				instanceMap{
+					"id-1": {},
+					"id-2": {},
+					"id-3": {},
+					"id-4": {},
+					"id-5": {},
+					"id-6": {},
+					"id-7": {},
+					"id-8": {},
+				},
+			),
+			maxSize:         aws.Int64(10),
+			numberExpected:  6,
+			loadingExpected: true,
+		},
+		{name: "Number higher than percentage and both valid so take the number",
+			asgTags: []*autoscaling.TagDescription{
+				{
+					Key:   aws.String("Name"),
+					Value: aws.String("asg-test"),
+				},
+				{
+					Key:   aws.String(OnDemandPercentageTag),
+					Value: aws.String("10"),
+				},
+				{
+					Key:   aws.String(OnDemandNumberLong),
+					Value: aws.String("3"),
+				},
+			},
+			asgInstances: makeInstancesWithCatalog(
+				instanceMap{
+					"id-1": {},
+					"id-2": {},
+					"id-3": {},
+					"id-4": {},
+				},
+			),
+			maxSize:         aws.Int64(10),
+			numberExpected:  3,
+			loadingExpected: true,
 		},
 	}
 


### PR DESCRIPTION
When an ASG has both "autospotting_min_on_demand_percentage" and
"autospotting_min_on_demand_number" tags, use whichever is the larger
number each time.  In other words, allow the static minimum number
of instances to override the percentage when the poolsize it small.

# Issue Type

- Feature Pull Request

## Summary

With this change in place, in the event an ASG has tags specifying both a static
number and a percentage for "minimum on-demand" instances, Autospotting will
use whichever is larger.

As a result, the static number can be used to enforce an absolute minimum which
will take precedence when the number of instances in the ASG is small.  But when
the ASG grows larger during higher traffic periods, the percentage will control the
minimum number of on-demand instances.  It allows for more aggressive spot use
when the ASG is large while never dropping below some fixed minimum in the
event the ASG shrinks to a small size during low traffic periods.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

## Code contribution checklist

1. [X] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [X] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [X] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [X] No issues are reported when running `make full-test`.
1. [X] Functionality not applicable to all users should be configurable.
1. [X] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [X] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [X] Tags names and expected values should be similar to the other existing
   configurations.
1. [] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
