### PR TITLE
Automatically upgrade EBS volumes of launched spot instances from GP2->GP3 and IO1->IO2 for lower cost and/or higher performance

### DIFF
--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -739,29 +739,6 @@ func (a *autoScalingGroup) terminateInstanceInAutoScalingGroup(
 	return nil
 }
 
-func (a *autoScalingGroup) hasLaunchLifecycleHooks() (bool, error) {
-
-	resDLH, err := a.region.services.autoScaling.DescribeLifecycleHooks(
-		&autoscaling.DescribeLifecycleHooksInput{
-			AutoScalingGroupName: a.AutoScalingGroupName,
-		})
-
-	if err != nil {
-		log.Println(err.Error())
-		return false, err
-	}
-
-	for _, hook := range resDLH.LifecycleHooks {
-		if *hook.LifecycleTransition == "autoscaling:EC2_INSTANCE_LAUNCHING" {
-			debug.Printf("Group %s has launch lifecycle hook(s): %s",
-				*a.AutoScalingGroupName, *hook.LifecycleHookName)
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
 // Counts the number of already running instances on-demand or spot, in any or a specific AZ.
 func (a *autoScalingGroup) alreadyRunningInstanceCount(
 	spot bool, availabilityZone *string) (int64, int64) {

--- a/core/instance.go
+++ b/core/instance.go
@@ -589,6 +589,9 @@ func (i *instance) convertBlockDeviceMappings(lc *launchConfiguration) []*ec2.Bl
 				VolumeSize:          lcBDM.Ebs.VolumeSize,
 				VolumeType:          lcBDM.Ebs.VolumeType,
 			}
+			if *ec2BDM.Ebs.VolumeType == "io1" {
+				*ec2BDM.Ebs.VolumeType = "io2"
+			}
 		}
 
 		// handle the noDevice field directly by skipping the device if set to true

--- a/core/instance.go
+++ b/core/instance.go
@@ -587,7 +587,7 @@ func (i *instance) getPriceToBid(
 func (i *instance) convertLaunchConfigurationBlockDeviceMappings(BDMs []*autoscaling.BlockDeviceMapping) []*ec2.BlockDeviceMapping {
 
 	bds := []*ec2.BlockDeviceMapping{}
-	if BDMs == nil || len(BDMs) == 0 {
+	if len(BDMs) == 0 {
 		debug.Println("Missing LC block device mappings")
 	}
 
@@ -625,7 +625,7 @@ func (i *instance) convertLaunchConfigurationBlockDeviceMappings(BDMs []*autosca
 func (i *instance) convertLaunchTemplateBlockDeviceMappings(BDMs []*ec2.LaunchTemplateBlockDeviceMapping) []*ec2.BlockDeviceMapping {
 
 	bds := []*ec2.BlockDeviceMapping{}
-	if BDMs == nil || len(BDMs) == 0 {
+	if len(BDMs) == 0 {
 		log.Println("Missing LT block device mappings")
 	}
 
@@ -663,7 +663,7 @@ func (i *instance) convertLaunchTemplateBlockDeviceMappings(BDMs []*ec2.LaunchTe
 func (i *instance) convertImageBlockDeviceMappings(BDMs []*ec2.BlockDeviceMapping) []*ec2.BlockDeviceMapping {
 
 	bds := []*ec2.BlockDeviceMapping{}
-	if BDMs == nil || len(BDMs) == 0 {
+	if len(BDMs) == 0 {
 		log.Println("Missing Image block device mappings")
 	}
 

--- a/core/instance.go
+++ b/core/instance.go
@@ -16,9 +16,22 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/davecgh/go-spew/spew"
 )
+
+var unsupportedIO2Regions = [...]string{
+	"us-gov-west-1",
+	"us-gov-east-1",
+	"sa-east-1",
+	"cn-north-1",
+	"cn-northwest-1",
+	"eu-south-1",
+	"af-south-1",
+	"eu-west-3",
+	"ap-northeast-3",
+}
 
 // The key in this map is the instance ID, useful for quick retrieval of
 // instance attributes.
@@ -515,10 +528,15 @@ func (i *instance) launchSpotReplacement() (*string, error) {
 	//Go through all compatible instances until one type launches or we are out of options.
 	for _, instanceType := range instanceTypes {
 		az := *i.Placement.AvailabilityZone
-		bidPrice := i.getPricetoBid(i.price,
+		bidPrice := i.getPriceToBid(i.price,
 			instanceType.pricing.spot[az], instanceType.pricing.premium)
 
-		runInstancesInput := i.createRunInstancesInput(instanceType.instanceType, bidPrice)
+		runInstancesInput, err := i.createRunInstancesInput(instanceType.instanceType, bidPrice)
+		if err != nil {
+			log.Println(az, i.asg.name, "Failed to generate run instances input, ", err.Error(), "skipping instance type ", instanceType.instanceType)
+			continue
+		}
+
 		log.Println(az, i.asg.name, "Launching spot instance of type", instanceType.instanceType, "with bid price", bidPrice)
 		log.Println(az, i.asg.name)
 		resp, err := i.region.services.ec2.RunInstances(runInstancesInput)
@@ -550,7 +568,7 @@ func (i *instance) launchSpotReplacement() (*string, error) {
 
 }
 
-func (i *instance) getPricetoBid(
+func (i *instance) getPriceToBid(
 	baseOnDemandPrice float64, currentSpotPrice float64, spotPremium float64) float64 {
 
 	debug.Println("BiddingPolicy: ", i.region.conf.BiddingPolicy)
@@ -566,42 +584,182 @@ func (i *instance) getPricetoBid(
 	return bufferPrice
 }
 
-func (i *instance) convertBlockDeviceMappings(lc *launchConfiguration) []*ec2.BlockDeviceMapping {
+func (i *instance) convertLaunchConfigurationBlockDeviceMappings(BDMs []*autoscaling.BlockDeviceMapping) []*ec2.BlockDeviceMapping {
+
 	bds := []*ec2.BlockDeviceMapping{}
-	if lc == nil || len(lc.BlockDeviceMappings) == 0 {
-		debug.Println("Missing block device mappings")
-		return bds
+	if BDMs == nil || len(BDMs) == 0 {
+		debug.Println("Missing LC block device mappings")
 	}
 
-	for _, lcBDM := range lc.BlockDeviceMappings {
+	for _, BDM := range BDMs {
 
 		ec2BDM := &ec2.BlockDeviceMapping{
-			DeviceName:  lcBDM.DeviceName,
-			VirtualName: lcBDM.VirtualName,
+			DeviceName:  BDM.DeviceName,
+			VirtualName: BDM.VirtualName,
 		}
 
-		if lcBDM.Ebs != nil {
+		if BDM.Ebs != nil {
 			ec2BDM.Ebs = &ec2.EbsBlockDevice{
-				DeleteOnTermination: lcBDM.Ebs.DeleteOnTermination,
-				Encrypted:           lcBDM.Ebs.Encrypted,
-				Iops:                lcBDM.Ebs.Iops,
-				SnapshotId:          lcBDM.Ebs.SnapshotId,
-				VolumeSize:          lcBDM.Ebs.VolumeSize,
-				VolumeType:          lcBDM.Ebs.VolumeType,
-			}
-			if *ec2BDM.Ebs.VolumeType == "io1" {
-				*ec2BDM.Ebs.VolumeType = "io2"
+				DeleteOnTermination: BDM.Ebs.DeleteOnTermination,
+				Encrypted:           BDM.Ebs.Encrypted,
+				Iops:                BDM.Ebs.Iops,
+				SnapshotId:          BDM.Ebs.SnapshotId,
+				VolumeSize:          BDM.Ebs.VolumeSize,
+				VolumeType:          convertLaunchConfigurationEBSVolumeType(BDM.Ebs, i.asg),
 			}
 		}
 
 		// handle the noDevice field directly by skipping the device if set to true
-		if lcBDM.NoDevice != nil && *lcBDM.NoDevice {
+		if BDM.NoDevice != nil && *BDM.NoDevice {
 			continue
 		}
 		bds = append(bds, ec2BDM)
+	}
 
+	if len(bds) == 0 {
+		return nil
 	}
 	return bds
+}
+
+func (i *instance) convertLaunchTemplateBlockDeviceMappings(BDMs []*ec2.LaunchTemplateBlockDeviceMapping) []*ec2.BlockDeviceMapping {
+
+	bds := []*ec2.BlockDeviceMapping{}
+	if BDMs == nil || len(BDMs) == 0 {
+		log.Println("Missing LT block device mappings")
+	}
+
+	for _, BDM := range BDMs {
+
+		ec2BDM := &ec2.BlockDeviceMapping{
+			DeviceName:  BDM.DeviceName,
+			VirtualName: BDM.VirtualName,
+		}
+
+		if BDM.Ebs != nil {
+			ec2BDM.Ebs = &ec2.EbsBlockDevice{
+				DeleteOnTermination: BDM.Ebs.DeleteOnTermination,
+				Encrypted:           BDM.Ebs.Encrypted,
+				Iops:                BDM.Ebs.Iops,
+				SnapshotId:          BDM.Ebs.SnapshotId,
+				VolumeSize:          BDM.Ebs.VolumeSize,
+				VolumeType:          convertLaunchTemplateEBSVolumeType(BDM.Ebs, i.asg),
+			}
+		}
+
+		// handle the noDevice field directly by skipping the device if set to true, apparently NoDevice is here a string instead of a bool.
+		if BDM.NoDevice != nil && *BDM.NoDevice == "true" {
+			continue
+		}
+		bds = append(bds, ec2BDM)
+	}
+
+	if len(bds) == 0 {
+		return nil
+	}
+	return bds
+}
+
+func (i *instance) convertImageBlockDeviceMappings(BDMs []*ec2.BlockDeviceMapping) []*ec2.BlockDeviceMapping {
+
+	bds := []*ec2.BlockDeviceMapping{}
+	if BDMs == nil || len(BDMs) == 0 {
+		log.Println("Missing Image block device mappings")
+	}
+
+	for _, BDM := range BDMs {
+
+		ec2BDM := &ec2.BlockDeviceMapping{
+			DeviceName:  BDM.DeviceName,
+			VirtualName: BDM.VirtualName,
+		}
+
+		if BDM.Ebs != nil {
+			ec2BDM.Ebs = &ec2.EbsBlockDevice{
+				DeleteOnTermination: BDM.Ebs.DeleteOnTermination,
+				Encrypted:           BDM.Ebs.Encrypted,
+				Iops:                BDM.Ebs.Iops,
+				SnapshotId:          BDM.Ebs.SnapshotId,
+				VolumeSize:          BDM.Ebs.VolumeSize,
+				VolumeType:          convertImageEBSVolumeType(BDM.Ebs, i.asg),
+			}
+		}
+
+		// handle the noDevice field directly by skipping the device if set to true, apparently NoDevice is here a string instead of a bool.
+		if BDM.NoDevice != nil && *BDM.NoDevice == "true" {
+			continue
+		}
+		bds = append(bds, ec2BDM)
+	}
+
+	if len(bds) == 0 {
+		return nil
+	}
+	return bds
+}
+
+func convertLaunchConfigurationEBSVolumeType(ebs *autoscaling.Ebs, a *autoScalingGroup) *string {
+	// convert IO1 to IO2 in supported regions
+	r := a.region.name
+	asg := a.name
+	if *ebs.VolumeType == "io1" && supportedIO2region(r) {
+		log.Println(r, ": Converting IO1 volume to IO2 for new instance launched for", asg)
+		return aws.String("io2")
+	}
+
+	// convert GP2 to GP3 below the threshold where GP2 becomes more performant. The Threshold is configurable
+	if *ebs.VolumeType == "gp2" && *ebs.VolumeSize <= a.config.GP2ConversionThreshold {
+		log.Println(r, ": Converting GP2 EBS volume to GP3 for new instance launched for", asg)
+		return aws.String("gp3")
+	}
+	log.Println(r, ": No EBS volume conversion could be done for", asg)
+	return ebs.VolumeType
+}
+
+func convertLaunchTemplateEBSVolumeType(ebs *ec2.LaunchTemplateEbsBlockDevice, a *autoScalingGroup) *string {
+	// convert IO1 to IO2 in supported regions
+	r := a.region.name
+	asg := a.name
+	if *ebs.VolumeType == "io1" && supportedIO2region(r) {
+		log.Println(r, ": Converting IO1 volume to IO2 for new instance launched for", asg)
+		return aws.String("io2")
+	}
+
+	// convert GP2 to GP3 below the threshold where GP2 becomes more performant. The Threshold is configurable
+	if *ebs.VolumeType == "gp2" && *ebs.VolumeSize <= a.config.GP2ConversionThreshold {
+		log.Println(r, ": Converting GP2 EBS volume to GP3 for new instance launched for", asg)
+		return aws.String("gp3")
+	}
+	log.Println(r, ": No EBS volume conversion could be done for", asg)
+	return ebs.VolumeType
+}
+
+func convertImageEBSVolumeType(ebs *ec2.EbsBlockDevice, a *autoScalingGroup) *string {
+	// convert IO1 to IO2 in supported regions
+	r := a.region.name
+	asg := a.name
+	if *ebs.VolumeType == "io1" && supportedIO2region(r) {
+		log.Println(r, ": Converting IO1 volume to IO2 for new instance launched for", asg)
+		return aws.String("io2")
+	}
+
+	// convert GP2 to GP3 below the threshold where GP2 becomes more performant. The Threshold is configurable
+	if *ebs.VolumeType == "gp2" && *ebs.VolumeSize <= a.config.GP2ConversionThreshold {
+		log.Println(r, ": Converting GP2 EBS volume to GP3 for new instance launched for", asg)
+		return aws.String("gp3")
+	}
+	log.Println(r, ": No EBS volume conversion could be done for", asg)
+	return ebs.VolumeType
+}
+
+func supportedIO2region(region string) bool {
+	for _, r := range unsupportedIO2Regions {
+		if region == r {
+			log.Println("IO2 EBS volumes are not available in", region)
+			return false
+		}
+	}
+	return true
 }
 
 func (i *instance) convertSecurityGroups() []*string {
@@ -612,7 +770,7 @@ func (i *instance) convertSecurityGroups() []*string {
 	return groupIDs
 }
 
-func (i *instance) launchTemplateHasNetworkInterfaces(id, ver *string) (bool, []*ec2.LaunchTemplateInstanceNetworkInterfaceSpecification) {
+func (i *instance) getlaunchTemplate(id, ver *string) (*ec2.ResponseLaunchTemplateData, error) {
 	res, err := i.region.services.ec2.DescribeLaunchTemplateVersions(
 		&ec2.DescribeLaunchTemplateVersionsInput{
 			Versions:         []*string{ver},
@@ -623,19 +781,131 @@ func (i *instance) launchTemplateHasNetworkInterfaces(id, ver *string) (bool, []
 	if err != nil {
 		log.Println("Failed to describe launch template", *id, "version", *ver,
 			"encountered error:", err.Error())
+		return nil, err
+	}
+	if len(res.LaunchTemplateVersions) == 1 {
+		return res.LaunchTemplateVersions[0].LaunchTemplateData, nil
+	}
+	return nil, fmt.Errorf("missing launch template version information")
+}
+
+func (i *instance) launchTemplateHasNetworkInterfaces(ltData *ec2.ResponseLaunchTemplateData) (bool, []*ec2.LaunchTemplateInstanceNetworkInterfaceSpecification) {
+	if ltData == nil {
+		log.Println("Missing launch template data for ", *i.InstanceId)
+		return false, nil
 	}
 
-	if err == nil && len(res.LaunchTemplateVersions) == 1 {
-		lt := res.LaunchTemplateVersions[0]
-		nis := lt.LaunchTemplateData.NetworkInterfaces
-		if len(nis) > 0 {
-			return true, nis
-		}
+	nis := ltData.NetworkInterfaces
+	if len(nis) > 0 {
+		return true, nis
 	}
 	return false, nil
 }
 
-func (i *instance) createRunInstancesInput(instanceType string, price float64) *ec2.RunInstancesInput {
+func (i *instance) processLaunchTemplate(retval *ec2.RunInstancesInput) error {
+	ver := i.asg.LaunchTemplate.Version
+	id := i.asg.LaunchTemplate.LaunchTemplateId
+
+	retval.LaunchTemplate = &ec2.LaunchTemplateSpecification{
+		LaunchTemplateId: id,
+		Version:          ver,
+	}
+
+	ltData, err := i.getlaunchTemplate(id, ver)
+	if err != nil {
+		return err
+	}
+
+	retval.BlockDeviceMappings = i.convertLaunchTemplateBlockDeviceMappings(ltData.BlockDeviceMappings)
+
+	if having, nis := i.launchTemplateHasNetworkInterfaces(ltData); having {
+		for _, ni := range nis {
+			retval.NetworkInterfaces = append(retval.NetworkInterfaces,
+				&ec2.InstanceNetworkInterfaceSpecification{
+					AssociatePublicIpAddress: ni.AssociatePublicIpAddress,
+					SubnetId:                 i.SubnetId,
+					DeviceIndex:              ni.DeviceIndex,
+					Groups:                   i.convertSecurityGroups(),
+				},
+			)
+		}
+		retval.SubnetId, retval.SecurityGroupIds = nil, nil
+	}
+	return nil
+}
+
+func (i *instance) processLaunchConfiguration(retval *ec2.RunInstancesInput) {
+	lc := i.asg.launchConfiguration
+
+	if lc.KeyName != nil && *lc.KeyName != "" {
+		retval.KeyName = lc.KeyName
+	}
+
+	if lc.IamInstanceProfile != nil {
+		if strings.HasPrefix(*lc.IamInstanceProfile, "arn:aws:iam:") {
+			retval.IamInstanceProfile = &ec2.IamInstanceProfileSpecification{
+				Arn: lc.IamInstanceProfile,
+			}
+		} else {
+			retval.IamInstanceProfile = &ec2.IamInstanceProfileSpecification{
+				Name: lc.IamInstanceProfile,
+			}
+		}
+	}
+	retval.ImageId = lc.ImageId
+
+	if strings.ToLower(i.asg.config.PatchBeanstalkUserdata) == "true" {
+		retval.UserData = getPatchedUserDataForBeanstalk(lc.UserData)
+	} else {
+		retval.UserData = lc.UserData
+	}
+
+	BDMs := i.convertLaunchConfigurationBlockDeviceMappings(lc.BlockDeviceMappings)
+
+	if len(BDMs) > 0 {
+		retval.BlockDeviceMappings = BDMs
+	}
+
+	if lc.InstanceMonitoring != nil {
+		retval.Monitoring = &ec2.RunInstancesMonitoringEnabled{
+			Enabled: lc.InstanceMonitoring.Enabled}
+	}
+
+	if lc.AssociatePublicIpAddress != nil || i.SubnetId != nil {
+		// Instances are running in a VPC.
+		retval.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{
+			{
+				AssociatePublicIpAddress: lc.AssociatePublicIpAddress,
+				DeviceIndex:              aws.Int64(0),
+				SubnetId:                 i.SubnetId,
+				Groups:                   i.convertSecurityGroups(),
+			},
+		}
+		retval.SubnetId, retval.SecurityGroupIds = nil, nil
+	}
+}
+
+func (i *instance) processImageBlockDevices(rii *ec2.RunInstancesInput) {
+	svc := i.region.services.ec2
+
+	resp, err := svc.DescribeImages(
+		&ec2.DescribeImagesInput{
+			ImageIds: []*string{i.ImageId},
+		})
+
+	if err != nil {
+		log.Println(err.Error())
+		return
+	}
+	if len(resp.Images) == 0 {
+		log.Println("missing image data")
+		return
+	}
+
+	rii.BlockDeviceMappings = i.convertImageBlockDeviceMappings(resp.Images[0].BlockDeviceMappings)
+}
+
+func (i *instance) createRunInstancesInput(instanceType string, price float64) (*ec2.RunInstancesInput, error) {
 	// information we must (or can safely) copy/convert from the currently running
 	// on-demand instance or we had to compute in order to place the spot bid
 	retval := ec2.RunInstancesInput{
@@ -661,82 +931,20 @@ func (i *instance) createRunInstancesInput(instanceType string, price float64) *
 		TagSpecifications: i.generateTagsList(),
 	}
 
+	i.processImageBlockDevices(&retval)
+
+	//populate the rest of the retval fields from launch Template and launch Configuration
 	if i.asg.LaunchTemplate != nil {
-		ver := i.asg.LaunchTemplate.Version
-		id := i.asg.LaunchTemplate.LaunchTemplateId
-
-		retval.LaunchTemplate = &ec2.LaunchTemplateSpecification{
-			LaunchTemplateId: id,
-			Version:          ver,
-		}
-
-		if having, nis := i.launchTemplateHasNetworkInterfaces(id, ver); having {
-			for _, ni := range nis {
-				retval.NetworkInterfaces = append(retval.NetworkInterfaces,
-					&ec2.InstanceNetworkInterfaceSpecification{
-						AssociatePublicIpAddress: ni.AssociatePublicIpAddress,
-						SubnetId:                 i.SubnetId,
-						DeviceIndex:              ni.DeviceIndex,
-						Groups:                   i.convertSecurityGroups(),
-					},
-				)
-			}
-			retval.SubnetId, retval.SecurityGroupIds = nil, nil
+		err := i.processLaunchTemplate(&retval)
+		if err != nil {
+			log.Println("failed to process launch template, the resulting instance configuration may be incomplete", err.Error())
+			return nil, err
 		}
 	}
-
 	if i.asg.launchConfiguration != nil {
-		lc := i.asg.launchConfiguration
-
-		if lc.KeyName != nil && *lc.KeyName != "" {
-			retval.KeyName = lc.KeyName
-		}
-
-		if lc.IamInstanceProfile != nil {
-			if strings.HasPrefix(*lc.IamInstanceProfile, "arn:aws:iam:") {
-				retval.IamInstanceProfile = &ec2.IamInstanceProfileSpecification{
-					Arn: lc.IamInstanceProfile,
-				}
-			} else {
-				retval.IamInstanceProfile = &ec2.IamInstanceProfileSpecification{
-					Name: lc.IamInstanceProfile,
-				}
-			}
-		}
-		retval.ImageId = lc.ImageId
-
-		if strings.ToLower(i.asg.config.PatchBeanstalkUserdata) == "true" {
-			retval.UserData = getPatchedUserDataForBeanstalk(lc.UserData)
-		} else {
-			retval.UserData = lc.UserData
-		}
-
-		BDMs := i.convertBlockDeviceMappings(lc)
-
-		if len(BDMs) > 0 {
-			retval.BlockDeviceMappings = BDMs
-		}
-
-		if lc.InstanceMonitoring != nil {
-			retval.Monitoring = &ec2.RunInstancesMonitoringEnabled{
-				Enabled: lc.InstanceMonitoring.Enabled}
-		}
-
-		if lc.AssociatePublicIpAddress != nil || i.SubnetId != nil {
-			// Instances are running in a VPC.
-			retval.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{
-				{
-					AssociatePublicIpAddress: lc.AssociatePublicIpAddress,
-					DeviceIndex:              aws.Int64(0),
-					SubnetId:                 i.SubnetId,
-					Groups:                   i.convertSecurityGroups(),
-				},
-			}
-			retval.SubnetId, retval.SecurityGroupIds = nil, nil
-		}
+		i.processLaunchConfiguration(&retval)
 	}
-
-	return &retval
+	return &retval, nil
 }
 
 func (i *instance) generateTagsList() []*ec2.TagSpecification {

--- a/core/instance_test.go
+++ b/core/instance_test.go
@@ -1439,7 +1439,7 @@ func Test_instance_convertBlockDeviceMappings(t *testing.T) {
 		},
 
 		{
-			name: "instance-store and EBS",
+			name: "instance-store and gp2 EBS",
 			lc: &launchConfiguration{
 				LaunchConfiguration: &autoscaling.LaunchConfiguration{
 					BlockDeviceMappings: []*autoscaling.BlockDeviceMapping{
@@ -1453,6 +1453,7 @@ func Test_instance_convertBlockDeviceMappings(t *testing.T) {
 							Ebs: &autoscaling.Ebs{
 								DeleteOnTermination: aws.Bool(false),
 								VolumeSize:          aws.Int64(10),
+								VolumeType:          aws.String("gp2"),
 							},
 							VirtualName: aws.String("bar"),
 						},
@@ -1461,6 +1462,7 @@ func Test_instance_convertBlockDeviceMappings(t *testing.T) {
 							Ebs: &autoscaling.Ebs{
 								DeleteOnTermination: aws.Bool(true),
 								VolumeSize:          aws.Int64(20),
+								VolumeType:          aws.String("gp2"),
 							},
 							VirtualName: aws.String("baz"),
 						},
@@ -1478,6 +1480,7 @@ func Test_instance_convertBlockDeviceMappings(t *testing.T) {
 					Ebs: &ec2.EbsBlockDevice{
 						DeleteOnTermination: aws.Bool(false),
 						VolumeSize:          aws.Int64(10),
+						VolumeType:          aws.String("gp2"),
 					},
 					VirtualName: aws.String("bar"),
 				},
@@ -1486,6 +1489,54 @@ func Test_instance_convertBlockDeviceMappings(t *testing.T) {
 					Ebs: &ec2.EbsBlockDevice{
 						DeleteOnTermination: aws.Bool(true),
 						VolumeSize:          aws.Int64(20),
+						VolumeType:          aws.String("gp2"),
+					},
+					VirtualName: aws.String("baz"),
+				},
+			},
+		},
+		{
+			name: "Provision io2 EBS volumes instead of io1",
+			lc: &launchConfiguration{
+				LaunchConfiguration: &autoscaling.LaunchConfiguration{
+					BlockDeviceMappings: []*autoscaling.BlockDeviceMapping{
+						{
+							DeviceName: aws.String("/dev/xvda"),
+							Ebs: &autoscaling.Ebs{
+								DeleteOnTermination: aws.Bool(false),
+								VolumeSize:          aws.Int64(10),
+								VolumeType:          aws.String("gp2"),
+							},
+							VirtualName: aws.String("bar"),
+						},
+						{
+							DeviceName: aws.String("/dev/xvdb"),
+							Ebs: &autoscaling.Ebs{
+								DeleteOnTermination: aws.Bool(true),
+								VolumeSize:          aws.Int64(20),
+								VolumeType:          aws.String("io1"),
+							},
+							VirtualName: aws.String("baz"),
+						},
+					},
+				},
+			},
+			want: []*ec2.BlockDeviceMapping{
+				{
+					DeviceName: aws.String("/dev/xvda"),
+					Ebs: &ec2.EbsBlockDevice{
+						DeleteOnTermination: aws.Bool(false),
+						VolumeSize:          aws.Int64(10),
+						VolumeType:          aws.String("gp2"),
+					},
+					VirtualName: aws.String("bar"),
+				},
+				{
+					DeviceName: aws.String("/dev/xvdb"),
+					Ebs: &ec2.EbsBlockDevice{
+						DeleteOnTermination: aws.Bool(true),
+						VolumeSize:          aws.Int64(20),
+						VolumeType:          aws.String("io2"),
 					},
 					VirtualName: aws.String("baz"),
 				},

--- a/core/instance_test.go
+++ b/core/instance_test.go
@@ -1103,7 +1103,7 @@ func TestGetCheapestCompatibleSpotInstanceType(t *testing.T) {
 	}
 }
 
-func TestGetPricetoBid(t *testing.T) {
+func TestGetPriceToBid(t *testing.T) {
 	tests := []struct {
 		spotPercentage       float64
 		currentSpotPrice     float64
@@ -1180,7 +1180,7 @@ func TestGetPricetoBid(t *testing.T) {
 		currentSpotPrice := tt.currentSpotPrice
 		currentOnDemandPrice := tt.currentOnDemandPrice
 		currentSpotPremium := tt.spotPremium
-		actualPrice := i.getPricetoBid(currentOnDemandPrice, currentSpotPrice, currentSpotPremium)
+		actualPrice := i.getPriceToBid(currentOnDemandPrice, currentSpotPrice, currentSpotPremium)
 		if math.Abs(actualPrice-tt.want) > 0.000001 {
 			t.Errorf("percentage = %.2f, policy = %s, expected price = %.5f, want %.5f, currentSpotPrice = %.5f",
 				tt.spotPercentage, tt.policy, actualPrice, tt.want, currentSpotPrice)
@@ -1390,45 +1390,36 @@ func TestGenerateTagList(t *testing.T) {
 	}
 }
 
-func Test_instance_convertBlockDeviceMappings(t *testing.T) {
+func Test_instance_convertLaunchConfigurationBlockDeviceMappings(t *testing.T) {
 
 	tests := []struct {
 		name string
-		lc   *launchConfiguration
+		BDMs []*autoscaling.BlockDeviceMapping
+		i    *instance
 		want []*ec2.BlockDeviceMapping
 	}{
 		{
-			name: "nil launch configuration",
-			lc:   nil,
-			want: []*ec2.BlockDeviceMapping{},
-		}, {
 			name: "nil block device mapping",
-			lc: &launchConfiguration{
-				LaunchConfiguration: &autoscaling.LaunchConfiguration{
-					BlockDeviceMappings: nil,
-				},
-			},
-			want: []*ec2.BlockDeviceMapping{},
+			BDMs: nil,
+			i:    &instance{},
+			want: nil,
 		},
 		{
 			name: "instance-store only, skipping one of the volumes from the BDMs",
-			lc: &launchConfiguration{
-				LaunchConfiguration: &autoscaling.LaunchConfiguration{
-					BlockDeviceMappings: []*autoscaling.BlockDeviceMapping{
-						{
-							DeviceName:  aws.String("/dev/ephemeral0"),
-							Ebs:         nil,
-							NoDevice:    aws.Bool(true),
-							VirtualName: aws.String("foo"),
-						},
-						{
-							DeviceName:  aws.String("/dev/ephemeral1"),
-							Ebs:         nil,
-							VirtualName: aws.String("bar"),
-						},
-					},
+			BDMs: []*autoscaling.BlockDeviceMapping{
+				{
+					DeviceName:  aws.String("/dev/ephemeral0"),
+					Ebs:         nil,
+					NoDevice:    aws.Bool(true),
+					VirtualName: aws.String("foo"),
+				},
+				{
+					DeviceName:  aws.String("/dev/ephemeral1"),
+					Ebs:         nil,
+					VirtualName: aws.String("bar"),
 				},
 			},
+			i: &instance{},
 			want: []*ec2.BlockDeviceMapping{
 				{
 					DeviceName:  aws.String("/dev/ephemeral1"),
@@ -1439,33 +1430,31 @@ func Test_instance_convertBlockDeviceMappings(t *testing.T) {
 		},
 
 		{
-			name: "instance-store and gp2 EBS",
-			lc: &launchConfiguration{
-				LaunchConfiguration: &autoscaling.LaunchConfiguration{
-					BlockDeviceMappings: []*autoscaling.BlockDeviceMapping{
-						{
-							DeviceName:  aws.String("/dev/ephemeral0"),
-							Ebs:         nil,
-							VirtualName: aws.String("foo"),
-						},
-						{
-							DeviceName: aws.String("/dev/xvda"),
-							Ebs: &autoscaling.Ebs{
-								DeleteOnTermination: aws.Bool(false),
-								VolumeSize:          aws.Int64(10),
-								VolumeType:          aws.String("gp2"),
-							},
-							VirtualName: aws.String("bar"),
-						},
-						{
-							DeviceName: aws.String("/dev/xvdb"),
-							Ebs: &autoscaling.Ebs{
-								DeleteOnTermination: aws.Bool(true),
-								VolumeSize:          aws.Int64(20),
-								VolumeType:          aws.String("gp2"),
-							},
-							VirtualName: aws.String("baz"),
-						},
+			name: "GP2 EBS to be converted to GP3 when size it below the configured threshold",
+			BDMs: []*autoscaling.BlockDeviceMapping{
+				{
+					DeviceName:  aws.String("/dev/ephemeral0"),
+					Ebs:         nil,
+					VirtualName: aws.String("foo"),
+				},
+				{
+					DeviceName: aws.String("/dev/xvda"),
+					Ebs: &autoscaling.Ebs{
+						DeleteOnTermination: aws.Bool(false),
+						VolumeSize:          aws.Int64(10),
+						VolumeType:          aws.String("gp2"),
+					},
+					VirtualName: aws.String("bar"),
+				},
+			},
+			i: &instance{
+				asg: &autoScalingGroup{
+					name: "asg-with",
+					region: &region{
+						name: "not-blacklisted",
+					},
+					config: AutoScalingConfig{
+						GP2ConversionThreshold: 100,
 					},
 				},
 			},
@@ -1480,57 +1469,80 @@ func Test_instance_convertBlockDeviceMappings(t *testing.T) {
 					Ebs: &ec2.EbsBlockDevice{
 						DeleteOnTermination: aws.Bool(false),
 						VolumeSize:          aws.Int64(10),
-						VolumeType:          aws.String("gp2"),
+						VolumeType:          aws.String("gp3"),
 					},
 					VirtualName: aws.String("bar"),
-				},
-				{
-					DeviceName: aws.String("/dev/xvdb"),
-					Ebs: &ec2.EbsBlockDevice{
-						DeleteOnTermination: aws.Bool(true),
-						VolumeSize:          aws.Int64(20),
-						VolumeType:          aws.String("gp2"),
-					},
-					VirtualName: aws.String("baz"),
 				},
 			},
 		},
 		{
-			name: "Provision io2 EBS volumes instead of io1",
-			lc: &launchConfiguration{
-				LaunchConfiguration: &autoscaling.LaunchConfiguration{
-					BlockDeviceMappings: []*autoscaling.BlockDeviceMapping{
-						{
-							DeviceName: aws.String("/dev/xvda"),
-							Ebs: &autoscaling.Ebs{
-								DeleteOnTermination: aws.Bool(false),
-								VolumeSize:          aws.Int64(10),
-								VolumeType:          aws.String("gp2"),
-							},
-							VirtualName: aws.String("bar"),
-						},
-						{
-							DeviceName: aws.String("/dev/xvdb"),
-							Ebs: &autoscaling.Ebs{
-								DeleteOnTermination: aws.Bool(true),
-								VolumeSize:          aws.Int64(20),
-								VolumeType:          aws.String("io1"),
-							},
-							VirtualName: aws.String("baz"),
-						},
+			name: "GP2 EBS to be kept as it is when size it above the configured threshold",
+			BDMs: []*autoscaling.BlockDeviceMapping{
+				{
+					DeviceName:  aws.String("/dev/ephemeral0"),
+					Ebs:         nil,
+					VirtualName: aws.String("foo"),
+				},
+				{
+					DeviceName: aws.String("/dev/xvda"),
+					Ebs: &autoscaling.Ebs{
+						DeleteOnTermination: aws.Bool(false),
+						VolumeSize:          aws.Int64(150),
+						VolumeType:          aws.String("gp2"),
+					},
+					VirtualName: aws.String("bar"),
+				},
+			},
+			i: &instance{
+				asg: &autoScalingGroup{
+					name: "asg-with",
+					region: &region{
+						name: "not-blacklisted",
+					},
+					config: AutoScalingConfig{
+						GP2ConversionThreshold: 100,
 					},
 				},
 			},
 			want: []*ec2.BlockDeviceMapping{
 				{
+					DeviceName:  aws.String("/dev/ephemeral0"),
+					Ebs:         nil,
+					VirtualName: aws.String("foo"),
+				},
+				{
 					DeviceName: aws.String("/dev/xvda"),
 					Ebs: &ec2.EbsBlockDevice{
 						DeleteOnTermination: aws.Bool(false),
-						VolumeSize:          aws.Int64(10),
+						VolumeSize:          aws.Int64(150),
 						VolumeType:          aws.String("gp2"),
 					},
 					VirtualName: aws.String("bar"),
 				},
+			},
+		},
+		{
+			name: "Provision IO2 EBS volume instead of IO1 in a supported region",
+			BDMs: []*autoscaling.BlockDeviceMapping{
+				{
+					DeviceName: aws.String("/dev/xvdb"),
+					Ebs: &autoscaling.Ebs{
+						DeleteOnTermination: aws.Bool(true),
+						VolumeSize:          aws.Int64(20),
+						VolumeType:          aws.String("io1"),
+					},
+					VirtualName: aws.String("baz"),
+				},
+			},
+			i: &instance{
+				asg: &autoScalingGroup{
+					name: "asg-with",
+					region: &region{
+						name: "supported",
+					},
+				},
+			},
+			want: []*ec2.BlockDeviceMapping{
 				{
 					DeviceName: aws.String("/dev/xvdb"),
 					Ebs: &ec2.EbsBlockDevice{
@@ -1542,12 +1554,46 @@ func Test_instance_convertBlockDeviceMappings(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Provision IO1 EBS volume instead of replacing to IO2 in an unsupported region",
+			BDMs: []*autoscaling.BlockDeviceMapping{
+
+				{
+					DeviceName: aws.String("/dev/xvdb"),
+					Ebs: &autoscaling.Ebs{
+						DeleteOnTermination: aws.Bool(true),
+						VolumeSize:          aws.Int64(20),
+						VolumeType:          aws.String("io1"),
+					},
+					VirtualName: aws.String("baz"),
+				},
+			},
+			i: &instance{
+				asg: &autoScalingGroup{
+					name: "asg-with",
+					region: &region{
+						name: "us-gov-west-1",
+					},
+				},
+			},
+			want: []*ec2.BlockDeviceMapping{
+				{
+					DeviceName: aws.String("/dev/xvdb"),
+					Ebs: &ec2.EbsBlockDevice{
+						DeleteOnTermination: aws.Bool(true),
+						VolumeSize:          aws.Int64(20),
+						VolumeType:          aws.String("io1"),
+					},
+					VirtualName: aws.String("baz"),
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			i := &instance{}
-			if got := i.convertBlockDeviceMappings(tt.lc); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("instance.convertBlockDeviceMappings() = %v, want %v", got, tt.want)
+			i := tt.i
+			if got := i.convertLaunchConfigurationBlockDeviceMappings(tt.BDMs); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("instance.convertLaunchConfigurationBlockDeviceMappings() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -1637,6 +1683,9 @@ func Test_instance_createRunInstancesInput(t *testing.T) {
 					services: connections{
 						ec2: mockEC2{
 							dltverr: nil,
+							damio: &ec2.DescribeImagesOutput{
+								Images: []*ec2.Image{},
+							},
 							dltvo: &ec2.DescribeLaunchTemplateVersionsOutput{
 								LaunchTemplateVersions: []*ec2.LaunchTemplateVersion{
 									{
@@ -1687,9 +1736,7 @@ func Test_instance_createRunInstancesInput(t *testing.T) {
 				price:        1.5,
 			},
 			want: &ec2.RunInstancesInput{
-
 				EbsOptimized: aws.Bool(true),
-
 				InstanceMarketOptions: &ec2.InstanceMarketOptionsRequest{
 					MarketType: aws.String(Spot),
 					SpotOptions: &ec2.SpotMarketOptions{
@@ -1752,6 +1799,9 @@ func Test_instance_createRunInstancesInput(t *testing.T) {
 				region: &region{
 					services: connections{
 						ec2: mockEC2{
+							damio: &ec2.DescribeImagesOutput{
+								Images: []*ec2.Image{},
+							},
 							dltverr: nil,
 							dltvo: &ec2.DescribeLaunchTemplateVersionsOutput{
 								LaunchTemplateVersions: []*ec2.LaunchTemplateVersion{
@@ -1810,7 +1860,6 @@ func Test_instance_createRunInstancesInput(t *testing.T) {
 				price:        1.5,
 			},
 			want: &ec2.RunInstancesInput{
-
 				EbsOptimized: aws.Bool(true),
 
 				InstanceMarketOptions: &ec2.InstanceMarketOptionsRequest{
@@ -1872,6 +1921,15 @@ func Test_instance_createRunInstancesInput(t *testing.T) {
 		{
 			name: "create run instances input with simple LC",
 			inst: instance{
+				region: &region{
+					services: connections{
+						ec2: mockEC2{
+							damio: &ec2.DescribeImagesOutput{
+								Images: []*ec2.Image{},
+							},
+						},
+					},
+				},
 				asg: &autoScalingGroup{
 					name: "mygroup",
 					Group: &autoscaling.Group{
@@ -1981,6 +2039,15 @@ func Test_instance_createRunInstancesInput(t *testing.T) {
 		{
 			name: "create run instances input with full launch configuration",
 			inst: instance{
+				region: &region{
+					services: connections{
+						ec2: mockEC2{
+							damio: &ec2.DescribeImagesOutput{
+								Images: []*ec2.Image{},
+							},
+						},
+					},
+				},
 				asg: &autoScalingGroup{
 					name: "mygroup",
 					Group: &autoscaling.Group{
@@ -2112,6 +2179,15 @@ func Test_instance_createRunInstancesInput(t *testing.T) {
 		{
 			name: "create run instances input with customized UserData for Beanstalk",
 			inst: instance{
+				region: &region{
+					services: connections{
+						ec2: mockEC2{
+							damio: &ec2.DescribeImagesOutput{
+								Images: []*ec2.Image{},
+							},
+						},
+					},
+				},
 				asg: &autoScalingGroup{
 					name: "mygroup",
 					Group: &autoscaling.Group{
@@ -2245,7 +2321,7 @@ func Test_instance_createRunInstancesInput(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			got := tt.inst.createRunInstancesInput(tt.args.instanceType, tt.args.price)
+			got, _ := tt.inst.createRunInstancesInput(tt.args.instanceType, tt.args.price)
 
 			// make sure the lists of tags are sorted, otherwise the comparison fails
 			sort.Slice(got.TagSpecifications[0].Tags, func(i, j int) bool {

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/aws/aws-sdk-go/service/lambda"
-	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 )
@@ -207,19 +205,6 @@ type mockCloudFormation struct {
 
 func (m mockCloudFormation) DescribeStacks(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
 	return m.dso, m.dserr
-}
-
-// All fields are composed of the abbreviation of their method
-// This is useful when methods are doing multiple calls to AWS API
-type mockLambda struct {
-	lambdaiface.LambdaAPI
-	// Invoke
-	io   *lambda.InvokeOutput
-	ierr error
-}
-
-func (m mockLambda) Invoke(*lambda.InvokeInput) (*lambda.InvokeOutput, error) {
-	return m.io, m.ierr
 }
 
 // All fields are composed of the abbreviation of their method


### PR DESCRIPTION
# Issue Type

- Feature Pull Request

## Summary

As per https://aws.amazon.com/blogs/aws/new-ebs-volume-type-io2-more-iops-gib-higher-durability/ they have 100x Higher Durability and 10x More IOPS/GiB at the same cost. Similar awesomeness is available on GP3 as per https://aws.amazon.com/blogs/aws/new-amazon-ebs-gp3-volume-lets-you-provision-performance-separate-from-capacity-and-offers-20-lower-price/

What we have so far:
    - Added configuration support with per-ASG tag-based overrides for the GP2 threshold
    - Set default threshold value to 170GB, apparently that's the threshold where GP2 bandwidth overtakes the GP3, but for IOPS the threshold is at 1TB. This is configurable at the Lambda binary level but not yet exposed through CloudFormation/Terraform
    - Add regional blacklist for the IO1->IO2 conversion for the regions where it's not yet supported
    - Reworked LaunchConfiguration and LaunchTemplate processing when creating the RunInstances input data
    - Added support for also processing the Block Device Mappings set by the AMI, with new overrides from the Launch Template level in addition to the existing ones for Launch Configurations
    - Added basic unit tests for the Launch Template conversion process
    - Tested and working as expected using ASG tag overrides for instances having BDMs configured at the AMI level, but without LC overrides.
    
ToDo:
    - Add CloudFormation and Terraform support for setting the Lambda environment variables based on stack parameter for overriding the 170GB default GP2 Threshold value.
    - Test the LC and LT overrides
    - Add tests for the AMI and LC BDM conversion logic

Current test results, with threshold set at 20 GB using ASG tag overrides:
![image](https://user-images.githubusercontent.com/95209/101229711-e08e7880-36a1-11eb-94fa-84f1565e657b.png)


<!--
Describe the change, including rationale and design decisions, and use a brief
but descriptive PR title.

Please include "Fixes #nnn" here or in your commit message in order to
link to an issue in which you describe the addressed problem in more detail.

If you want to address more issues do it in different pull requests instead of a
single big one, it will speed up the review process considerably.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [x] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1.  [x] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
