### PR TITLE
Add log output after having processed all regions that show actions taken by AS ScheduleRun

### DIFF
--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -124,7 +124,7 @@ func (a *autoScalingGroup) terminateRandomSpotInstanceIfHavingEnough(totalRunnin
 
 	if isTerminated == nil {
 		// add to FinalRecap
-		recapText := fmt.Sprintf("%s %s Terminated random spot instance %s [too few onDemands]", a.name, *randomSpot.Instance.InstanceId)
+		recapText := fmt.Sprintf("%s Terminated random spot instance %s [too few onDemands]", a.name, *randomSpot.Instance.InstanceId)
 		a.region.conf.FinalRecap[a.region.name] = append(a.region.conf.FinalRecap[a.region.name], recapText)
 	}
 
@@ -214,7 +214,7 @@ func (a *autoScalingGroup) cronEventAction() runer {
 
 	if need, total := a.needReplaceOnDemandInstances(); !need || !shouldRun {
 		// add to FinalRecap
-		recapText := fmt.Sprintf("%s %s Terminated spot instance %s [not needed]", a.name, spotInstanceID)
+		recapText := fmt.Sprintf("%s Terminated spot instance %s [not needed]", a.name, spotInstanceID)
 		a.region.conf.FinalRecap[a.region.name] = append(a.region.conf.FinalRecap[a.region.name], recapText)
 		return terminateUnneededSpotInstance{
 			target{
@@ -389,7 +389,7 @@ func (a *autoScalingGroup) replaceOnDemandInstanceWithSpot(odInstanceID *string,
 
 	if isTerminated == nil {
 		// add to FinalRecap
-		recapText := fmt.Sprintf("%s %s OnDemand instance %s replaced with spot instance %s", a.name, *odInstanceID, *spotInst.InstanceId)
+		recapText := fmt.Sprintf("%s OnDemand instance %s replaced with spot instance %s", a.name, *odInstanceID, *spotInst.InstanceId)
 		a.region.conf.FinalRecap[a.region.name] = append(a.region.conf.FinalRecap[a.region.name], recapText)
 	}
 

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -124,7 +124,7 @@ func (a *autoScalingGroup) terminateRandomSpotInstanceIfHavingEnough(totalRunnin
 
 	if isTerminated == nil {
 		// add to FinalRecap
-		recapText := fmt.Sprintf("%s %s Terminated random spot instance %s [too few onDemands]", a.region.name, a.name, *randomSpot.Instance.InstanceId)
+		recapText := fmt.Sprintf("%s %s Terminated random spot instance %s [too few onDemands]", a.name, *randomSpot.Instance.InstanceId)
 		a.region.conf.FinalRecap[a.region.name] = append(a.region.conf.FinalRecap[a.region.name], recapText)
 	}
 
@@ -214,7 +214,7 @@ func (a *autoScalingGroup) cronEventAction() runer {
 
 	if need, total := a.needReplaceOnDemandInstances(); !need || !shouldRun {
 		// add to FinalRecap
-		recapText := fmt.Sprintf("%s %s Terminated spot instance %s [not needed]", a.region.name, a.name, spotInstanceID)
+		recapText := fmt.Sprintf("%s %s Terminated spot instance %s [not needed]", a.name, spotInstanceID)
 		a.region.conf.FinalRecap[a.region.name] = append(a.region.conf.FinalRecap[a.region.name], recapText)
 		return terminateUnneededSpotInstance{
 			target{
@@ -389,7 +389,7 @@ func (a *autoScalingGroup) replaceOnDemandInstanceWithSpot(odInstanceID *string,
 
 	if isTerminated == nil {
 		// add to FinalRecap
-		recapText := fmt.Sprintf("%s %s OnDemand instance %s replaced with spot instance %s", a.region.name, a.name, *odInstanceID, *spotInst.InstanceId)
+		recapText := fmt.Sprintf("%s %s OnDemand instance %s replaced with spot instance %s", a.name, *odInstanceID, *spotInst.InstanceId)
 		a.region.conf.FinalRecap[a.region.name] = append(a.region.conf.FinalRecap[a.region.name], recapText)
 	}
 

--- a/core/autoscaling_test.go
+++ b/core/autoscaling_test.go
@@ -2431,7 +2431,9 @@ func TestReplaceOnDemandInstanceWithSpot(t *testing.T) {
 				}),
 				region: &region{
 					name: "test-region",
-					conf: &Config{},
+					conf: &Config{
+						FinalRecap: make(map[string][]string),
+					},
 					services: connections{
 						autoScaling: &mockASG{
 							uasgo:     nil,
@@ -3998,6 +4000,7 @@ func Test_autoScalingGroup_cronEventAction(t *testing.T) {
 
 					MinOnDemandNumber: 1,
 				},
+				FinalRecap:  make(map[string][]string),
 				LicenseType: "custom",
 				Version:     "nightly",
 			},

--- a/core/config.go
+++ b/core/config.go
@@ -98,6 +98,9 @@ type Config struct {
 
 	// JSON file containing event data used for locally simulating execution from Lambda.
 	EventFile string
+
+	// Final Recap String Array to show actions taken by ScheduleRun on ASGs
+	FinalRecap map[string][]string
 }
 
 // ParseConfig loads configuration from command line flags, environments variables, and config files.
@@ -232,4 +235,6 @@ func ParseConfig(conf *Config) {
 		log.Fatal(err.Error())
 	}
 	conf.InstanceData = data
+
+	conf.FinalRecap = make(map[string][]string)
 }

--- a/core/instance.go
+++ b/core/instance.go
@@ -535,7 +535,7 @@ func (i *instance) launchSpotReplacement() (*string, error) {
 
 			debug.Println("RunInstances response:", spew.Sdump(resp))
 			// add to FinalRecap
-			recapText := fmt.Sprintf("%s %s Launched spot instance %s", i.region.name, i.asg.name, *spotInst.InstanceId)
+			recapText := fmt.Sprintf("%s %s Launched spot instance %s", i.asg.name, *spotInst.InstanceId)
 			i.region.conf.FinalRecap[i.region.name] = append(i.region.conf.FinalRecap[i.region.name], recapText)
 			return spotInst.InstanceId, nil
 		}

--- a/core/instance.go
+++ b/core/instance.go
@@ -534,6 +534,9 @@ func (i *instance) launchSpotReplacement() (*string, error) {
 				"current spot price", instanceType.pricing.spot[az])
 
 			debug.Println("RunInstances response:", spew.Sdump(resp))
+			// add to FinalRecap
+			recapText := fmt.Sprintf("%s %s Launched spot instance %s", i.region.name, i.asg.name, *spotInst.InstanceId)
+			i.region.conf.FinalRecap[i.region.name] = append(i.region.conf.FinalRecap[i.region.name], recapText)
 			return spotInst.InstanceId, nil
 		}
 	}

--- a/core/instance.go
+++ b/core/instance.go
@@ -535,7 +535,7 @@ func (i *instance) launchSpotReplacement() (*string, error) {
 
 			debug.Println("RunInstances response:", spew.Sdump(resp))
 			// add to FinalRecap
-			recapText := fmt.Sprintf("%s %s Launched spot instance %s", i.asg.name, *spotInst.InstanceId)
+			recapText := fmt.Sprintf("%s Launched spot instance %s", i.asg.name, *spotInst.InstanceId)
 			i.region.conf.FinalRecap[i.region.name] = append(i.region.conf.FinalRecap[i.region.name], recapText)
 			return spotInst.InstanceId, nil
 		}

--- a/core/main.go
+++ b/core/main.go
@@ -69,6 +69,7 @@ func (a *AutoSpotting) ProcessCronEvent() {
 	a.processRegions(allRegions)
 
 	// Print Final Recap
+	logger.Println("####### FINAL RECAP #######")
 	for r, a := range a.config.FinalRecap {
 		for _, t := range a {
 			logger.Printf("%s %s\n", r, t)

--- a/core/main.go
+++ b/core/main.go
@@ -55,6 +55,8 @@ func (a *AutoSpotting) Init(cfg *Config) {
 // enabled and taking action by replacing more pricy on-demand instances with
 // compatible and cheaper spot instances.
 func (a *AutoSpotting) ProcessCronEvent() {
+	// Clear FinalRecap map
+	a.config.FinalRecap = make(map[string][]string)
 
 	a.config.addDefaultFilteringMode()
 	a.config.addDefaultFilter()
@@ -69,7 +71,7 @@ func (a *AutoSpotting) ProcessCronEvent() {
 	a.processRegions(allRegions)
 
 	// Print Final Recap
-	logger.Println("####### FINAL RECAP #######")
+	logger.Println("####### BEGIN FINAL RECAP #######")
 	for r, a := range a.config.FinalRecap {
 		for _, t := range a {
 			logger.Printf("%s %s\n", r, t)

--- a/core/main.go
+++ b/core/main.go
@@ -68,6 +68,12 @@ func (a *AutoSpotting) ProcessCronEvent() {
 
 	a.processRegions(allRegions)
 
+	// Print Final Recap
+	for r, a := range a.config.FinalRecap {
+		for _, t := range a {
+			logger.Printf("%s %s\n", r, t)
+		}
+	}
 }
 
 func (cfg *Config) addDefaultFilteringMode() {


### PR DESCRIPTION
# Issue Type

<!--
Pick one below and delete the others.

Also feel free to delete these comments for brevity once they were fully
acknowledged.
-->

- Feature Pull Request

## Summary
As sometimes it's difficult to parse log output to find out which action have been taken by AutoSpotting schedule run, especially if you have many ASG, this PR add a final output after having processed all regions that show only if some action have been taken on an AutoScalingGroup (instance terminated, replaced or spot launched and so on)
Here an example output:
```
           SC:2020-10-22T11:40:00 2020/10/22 11:41:12 main.go:74: ####### BEGIN FINAL RECAP #######
           SC:2020-10-22T11:40:00 2020/10/22 11:41:12 main.go:77: eu-west-1 rmq-u-d-AutoScalingGroup-E0AA2BJJLA1I OnDemand instance i-02feae0a90d03651d replaced with spot instance i-04caa6efea8a30242
           SC:2020-10-22T11:16:00 2020/10/22 11:16:40 main.go:77: eu-west-1 els-u-d-AutoScalingGroup-V4UV43APWMHZ Launched spot instance i-08791721f770db501
           SC:2020-10-22T11:22:00 2020/10/22 11:22:38 main.go:77: eu-central-1 ecs-u-d-AutoScalingGroup-16M9XBTDZ43M2 Terminated spot instance i-00cca1a2835ebf303 [not needed]
           2020/10/22 11:41:12 Execution completed, nothing left to do
           END RequestId: e835f04a-a58a-421a-b5ea-66e1dc02912a
           REPORT RequestId: e835f04a-a58a-421a-b5ea-66e1dc02912a       Duration: 34836.55 ms   Billed Duration: 34900 ms       Memory Size: 256 MB     Max Memory Used: 178 MB
```
To achieve this i added a new property to Config called FinalRecap as a map of string slice.
As Config is passed as a pointer and as region name is the map key, there should be no problem regarding concurrent/parallel region execution changing the same "property".

Note:
I had to clear every time FinalRecap map (in ProcessCronEvent) because config may persist over differents AutoSpotting runs.

<!--
Describe the change, including rationale and design decisions, and use a brief
but descriptive PR title.

Please include "Fixes #nnn" here or in your commit message in order to
link to an issue in which you describe the addressed problem in more detail.

If you want to address more issues do it in different pull requests instead of a
single big one, it will speed up the review process considerably.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [X ] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
