### PR TITLE
re #430: allows counting ephemeral volumes desired via AMI specified by ASG launch template (w/ version)

### DIFF
--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -96,6 +96,10 @@ func (a *autoScalingGroup) loadLaunchTemplate() (*launchTemplate, error) {
 		return nil, err
 	}
 
+	if len(resp.LaunchTemplateVersions) == 0 {
+		return nil, errors.New("missing launch template")
+	}
+
 	ltv := resp.LaunchTemplateVersions[0]
 
 	params2 := &ec2.DescribeImagesInput{
@@ -107,6 +111,10 @@ func (a *autoScalingGroup) loadLaunchTemplate() (*launchTemplate, error) {
 	if err2 != nil {
 		logger.Println(err.Error())
 		return nil, err
+	}
+
+	if len(resp2.Images) == 0 {
+		return nil, errors.New("missing launch template image")
 	}
 
 	a.launchTemplate = &launchTemplate{

--- a/core/autoscaling.go
+++ b/core/autoscaling.go
@@ -69,8 +69,14 @@ func (a *autoScalingGroup) loadLaunchTemplate() (*launchTemplate, error) {
 		return a.launchTemplate, nil
 	}
 
-	ltID := a.LaunchTemplate.LaunchTemplateId
-	ltVer := a.LaunchTemplate.Version
+	lt := a.LaunchTemplate
+
+	if lt == nil {
+		return nil, errors.New("missing launch template")
+	}
+
+	ltID := lt.LaunchTemplateId
+	ltVer := lt.Version
 
 	if ltID == nil || ltVer == nil {
 		return nil, errors.New("missing launch template")

--- a/core/instance.go
+++ b/core/instance.go
@@ -246,6 +246,7 @@ func (i *instance) belongsToEnabledASG() bool {
 			asg.loadDefaultConfig()
 			asg.loadConfigFromTags()
 			asg.loadLaunchConfiguration()
+			asg.loadLaunchTemplate()
 			i.asg = &asg
 			i.price = i.typeInfo.pricing.onDemand / i.region.conf.OnDemandPriceMultiplier * i.asg.config.OnDemandPriceMultiplier
 			logger.Printf("%s instace %s belongs to enabled ASG %s", i.region.name,
@@ -445,7 +446,9 @@ func (i *instance) getCompatibleSpotInstanceTypesListSortedAscendingByPrice(allo
 	// device mappings, this number is used later when comparing with each
 	// instance type.
 
-	usedMappings := i.asg.launchConfiguration.countLaunchConfigEphemeralVolumes()
+	lcMappings := i.asg.launchConfiguration.countLaunchConfigEphemeralVolumes()
+	ltMappings := i.asg.launchTemplate.countLaunchTemplateEphemeralVolumes()
+	usedMappings := max(lcMappings, ltMappings)
 	attachedVolumesNumber := min(usedMappings, current.instanceStoreDeviceCount)
 
 	// Iterate alphabetically by instance type
@@ -913,6 +916,12 @@ func (i *instance) isReadyToAttach(asg *autoScalingGroup) bool {
 }
 func min(x, y int) int {
 	if x < y {
+		return x
+	}
+	return y
+}
+func max(x, y int) int {
+	if x > y {
 		return x
 	}
 	return y

--- a/core/launch_template.go
+++ b/core/launch_template.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2019 Cristian Măgherușan-Stanciu
+// Licensed under the Open Software License version 3.0
+
+package autospotting
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+type launchTemplate struct {
+	*ec2.LaunchTemplateVersion
+	*ec2.Image
+}
+
+func (lt *launchTemplate) countLaunchTemplateEphemeralVolumes() int {
+	count := 0
+
+	if lt == nil || lt.Image == nil || lt.Image.BlockDeviceMappings == nil {
+		return count
+	}
+
+	for _, mapping := range lt.Image.BlockDeviceMappings {
+		if mapping.VirtualName != nil &&
+			strings.Contains(*mapping.VirtualName, "ephemeral") {
+			debug.Println("Found ephemeral device mapping", *mapping.VirtualName)
+			count++
+		}
+	}
+
+	logger.Printf("Launch template version would attach %d ephemeral volumes if available", count)
+
+	return count
+}

--- a/core/launch_template_test.go
+++ b/core/launch_template_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016-2019 Cristian Măgherușan-Stanciu
+// Licensed under the Open Software License version 3.0
+
+package autospotting
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+func Test_countLaunchTemplateEphemeralVolumes(t *testing.T) {
+	tests := []struct {
+		name  string
+		lt    *launchTemplate
+		count int
+	}{
+		{
+			name:  "empty LaunchTemplate",
+			lt:    &launchTemplate{},
+			count: 0,
+		},
+		{
+			name: "empty BlockDeviceMappings",
+			lt: &launchTemplate{
+				LaunchTemplateVersion: &ec2.LaunchTemplateVersion{},
+				Image: &ec2.Image{
+					BlockDeviceMappings: []*ec2.BlockDeviceMapping{
+						{},
+					},
+				},
+			},
+			count: 0,
+		},
+		{
+			name: "mix of valid and invalid configuration",
+			lt: &launchTemplate{
+				LaunchTemplateVersion: &ec2.LaunchTemplateVersion{},
+				Image: &ec2.Image{
+					BlockDeviceMappings: []*ec2.BlockDeviceMapping{
+						{VirtualName: aws.String("ephemeral")},
+						{},
+					},
+				},
+			},
+			count: 1,
+		},
+		{
+			name: "valid configuration",
+			lt: &launchTemplate{
+				LaunchTemplateVersion: &ec2.LaunchTemplateVersion{},
+				Image: &ec2.Image{
+					BlockDeviceMappings: []*ec2.BlockDeviceMapping{
+						{VirtualName: aws.String("ephemeral")},
+						{VirtualName: aws.String("ephemeral")},
+					},
+				},
+			},
+			count: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			count := tc.lt.countLaunchTemplateEphemeralVolumes()
+			if count != tc.count {
+				t.Errorf("count expected: %d, actual: %d", tc.count, count)
+			}
+		})
+	}
+}

--- a/core/mock_test.go
+++ b/core/mock_test.go
@@ -45,6 +45,10 @@ type mockEC2 struct {
 	diao   *ec2.DescribeInstanceAttributeOutput
 	diaerr error
 
+	// DescribeImagesOutput
+	damio   *ec2.DescribeImagesOutput
+	damierr error
+
 	// Terminate Instance
 	tio   *ec2.TerminateInstancesOutput
 	tierr error
@@ -79,6 +83,10 @@ func (m mockEC2) DescribeInstancesPages(in *ec2.DescribeInstancesInput, f func(*
 
 func (m mockEC2) DescribeInstanceAttribute(in *ec2.DescribeInstanceAttributeInput) (*ec2.DescribeInstanceAttributeOutput, error) {
 	return m.diao, m.diaerr
+}
+
+func (m mockEC2) DescribeImages(in *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
+	return m.damio, m.damierr
 }
 
 func (m mockEC2) TerminateInstances(*ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {


### PR DESCRIPTION
# Issue Type

- Feature Pull Request

## Summary

Fixes #430, where ephemeral volumes weren't being counted from the AMI used by a launch template when considering the acceptable instance types.

## Code contribution checklist

1. [x] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [x] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [x] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [x] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
