### PR TITLE
Support for handling EC2 Rebalance Recommendation event

### DIFF
--- a/cloudformation/stacks/AutoSpotting/regional_template.yaml
+++ b/cloudformation/stacks/AutoSpotting/regional_template.yaml
@@ -27,7 +27,7 @@
           terminations"
         Handler: "index.handler"
         Runtime: "python3.6"
-        Timeout: "300"
+        Timeout: 300
         Environment:
           Variables:
             AUTOSPOTTING_LAMBDA_ARN:
@@ -132,6 +132,38 @@
         Targets:
           -
             Id: "InstanceRunningEventGenerator"
+            Arn:
+              Fn::GetAtt:
+                - "EventHandler"
+                - "Arn"
+    RebalanceRecommendationLambdaPermission:
+      Type: "AWS::Lambda::Permission"
+      Properties:
+        Action: "lambda:InvokeFunction"
+        FunctionName:
+          Ref: "EventHandler"
+        Principal: "events.amazonaws.com"
+        SourceArn:
+          Fn::GetAtt:
+            - "RebalanceRecommendationEventRule"
+            - "Arn"
+    RebalanceRecommendationEventRule:
+      Type: "AWS::Events::Rule"
+      Properties:
+        Description: >
+          "This rule is triggered when a Rebalance Recommendation is available"
+        EventPattern:
+          detail-type:
+            - "EC2 Instance Rebalance Recommendation"
+          source:
+            - "aws.ec2"
+          detail:
+            state:
+              - "running"
+        State: "ENABLED"
+        Targets:
+          -
+            Id: "RebalanceRecommendationEventGenerator"
             Arn:
               Fn::GetAtt:
                 - "EventHandler"

--- a/cloudformation/stacks/AutoSpotting/template.yaml
+++ b/cloudformation/stacks/AutoSpotting/template.yaml
@@ -141,7 +141,7 @@
         know what you're doing!"
       Type: "String"
     LambdaMemorySize:
-      Default: "1024"
+      Default: 1024
       Description: >
         "Memory allocated to the Lambda function, setting this lower will slow
         down the execution a bit"
@@ -465,6 +465,71 @@
               - Fn::GetAtt:
                   - "LambdaFunction"
                   - "Arn"
+    RebalanceRecommendationLambdaPermission:
+      Condition: "StackSetsTrue"
+      Type: "AWS::Lambda::Permission"
+      Properties:
+        Action: "lambda:InvokeFunction"
+        FunctionName: !If
+          - "StackSetsIsRegional"
+          - Ref: "EventHandler"
+          - Ref: "LambdaFunction"
+        Principal: "events.amazonaws.com"
+        SourceArn:
+          Fn::GetAtt:
+            - "RebalanceRecommendationEventRule"
+            - "Arn"
+    RebalanceRecommendationEventRule:
+      Condition: "StackSetsTrue"
+      Type: "AWS::Events::Rule"
+      Properties:
+        Description: "This rule is triggered when a Rebalance Recommendation is available"
+        EventPattern:
+          detail-type:
+            - "EC2 Instance Rebalance Recommendation"
+          source:
+            - "aws.ec2"
+        State: "ENABLED"
+        Targets:
+          -
+            Id: "RebalanceRecommendationEventGenerator"
+            InputTransformer: !If
+              - "StackSetsIsRegional"
+              -
+                InputPathsMap: {
+                  "id": "$.id",
+                  "detail-type": "$.detail-type",
+                  "source": "$.source",
+                  "account": "$.account",
+                  "time": "$.time",
+                  "region": "$.region",
+                  "resources": "$.resources",
+                  "detail": "$.detail"
+                }
+                InputTemplate: !Join ["",
+                  [
+                    "{",
+                    "\"id\": <id>,",
+                    "\"detail-type\": <detail-type>,",
+                    "\"source\": <source>,",
+                    "\"account\": <account>,",
+                    "\"time\": <time>,",
+                    "\"region\": <region>,",
+                    "\"resources\": <resources>,",
+                    "\"detail\": <detail>,",
+                    "\"AutospottingLambdaArn\": \"", !GetAtt RegionalStackSetCustomResource.AutoSpottingLambdaARN, "\"",
+                    "}"
+                  ]
+                ]
+              - !Ref 'AWS::NoValue'
+            Arn: !If
+              - "StackSetsIsRegional"
+              - Fn::GetAtt:
+                  - "EventHandler"
+                  - "Arn"
+              - Fn::GetAtt:
+                  - "LambdaFunction"
+                  - "Arn"
     LifecycleHookLambdaPermission:
       Condition: "StackSetsTrue"
       Type: "AWS::Lambda::Permission"
@@ -630,7 +695,7 @@
               Ref: "LambdaFunctionTagKey"
             Value:
               Ref: "LambdaFunctionTagValue"
-        Timeout: "900"
+        Timeout: 900
       Type: "AWS::Lambda::Function"
     LambdaPolicy:
       Condition: "StackIsMain"
@@ -686,7 +751,7 @@
         Description: "Invoked synchronously by the main Lambda to change ASG MaxSize if attachinstances method fail"
         Handler: "index.handler"
         Runtime: "python3.7"
-        Timeout: "120"
+        Timeout: 120
         ReservedConcurrentExecutions: 1
         Role: !GetAtt LambdaManageASGExecutionRole.Arn
         Code:
@@ -958,7 +1023,7 @@
         Description: "Creates regional CloudFormation stacks that trigger the main Lambda function on spot instance termination notification"
         Handler: "regional_stack_lambda.handler"
         Runtime: "python3.6"
-        Timeout: "900"
+        Timeout: 900
         Role:
           Fn::GetAtt:
             - "LambdaRegionalStackExecutionRole"
@@ -1006,7 +1071,7 @@
         Description: "Invokes the main AutoSpotting Lambda function on spot instance termination notification"
         Handler: "index.handler"
         Runtime: "python3.6"
-        Timeout: "300"
+        Timeout: 300
         Environment:
           Variables:
             AUTOSPOTTING_MAIN_REGION:

--- a/core/spot_termination.go
+++ b/core/spot_termination.go
@@ -68,6 +68,21 @@ func getInstanceIDDueForTermination(event events.CloudWatchEvent) (*string, erro
 	return nil, nil
 }
 
+func getInstanceIDDueForRebalance(event events.CloudWatchEvent) (*string, error) {
+
+	var detailData instanceData
+	if err := json.Unmarshal(event.Detail, &detailData); err != nil {
+		logger.Println(err.Error())
+		return nil, err
+	}
+
+	if detailData.InstanceID != nil && *detailData.InstanceID != "" {
+		return detailData.InstanceID, nil
+	}
+
+	return nil, nil
+}
+
 //DetachInstance detaches the instance from autoscaling group without decrementing the desired capacity
 //This makes sure that the autoscaling group spawns a new instance as soon as this instance is detached
 func (s *SpotTermination) detachInstance(instanceID *string, asgName string) error {


### PR DESCRIPTION
# Issue Type

- Feature Pull Request

## Summary

Fixes #448 by handling [EC2 Rebalance Recommendation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/rebalance-recommendations.html#monitor-rebalance-recommendations) event in the same way a Spot Interruption event was already handled by AutoSpotting.

## Code contribution checklist

1. [x] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [x] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [x] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
