### PR TITLE
Add explicit bucket permissions for regional resources deployment

### DIFF
--- a/cloudformation/stacks/AutoSpotting/template.yaml
+++ b/cloudformation/stacks/AutoSpotting/template.yaml
@@ -864,6 +864,13 @@
                 - "lambda:GetFunctionConfiguration"
               Effect: "Allow"
               Resource: "*"
+            - 
+              Action:
+                - "s3:Get*"
+              Effect: "Allow"
+              Resource: 
+                - Fn::Sub: "arn:${AWS::Partition}:s3:::${LambdaS3Bucket}"
+                - Fn::Sub: "arn:${AWS::Partition}:s3:::${LambdaS3Bucket}/${LambdaS3BucketPrefix}/*"
         PolicyName: "LambdaRegionalStackPolicy"
         Roles:
           -


### PR DESCRIPTION
# Issue Type

- Bugfix Pull Request

## Summary

When trying to launch AutoSpotting in my AWS account I got the following errors during creation of regional stacks (StackSet disabled)

>
	2020-11-11T10:22:53.462-03:00	Traceback (most recent call last):
	2020-11-11T10:22:53.462-03:00	File "/var/lang/lib/python3.6/threading.py", line 916, in _bootstrap_inner
	2020-11-11T10:22:53.462-03:00	self.run()
	2020-11-11T10:22:53.462-03:00	File "/var/lang/lib/python3.6/threading.py", line 864, in run
	2020-11-11T10:22:53.462-03:00	self._target(*self._args, **self._kwargs)
	2020-11-11T10:22:53.462-03:00	File "/var/task/regional_stack_lambda.py", line 47, in create_stack
	2020-11-11T10:22:53.462-03:00	'ParameterValue': role_arn,
	2020-11-11T10:22:53.462-03:00	File "/var/runtime/botocore/client.py", line 316, in _api_call
	2020-11-11T10:22:53.462-03:00	return self._make_api_call(operation_name, kwargs)
	2020-11-11T10:22:53.462-03:00	File "/var/runtime/botocore/client.py", line 635, in _make_api_call
	2020-11-11T10:22:53.462-03:00	raise error_class(parsed_response, operation_name)
	2020-11-11T10:22:53.462-03:00	botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the CreateStack operation: S3 error: Access Denied
	2020-11-11T10:22:53.462-03:00	For more information check http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html 


## Code contribution checklist


1. [x] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [x] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [x] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [x] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [x] No issues are reported when running `make full-test`.
1. [x] Functionality not applicable to all users should be configurable.
1. [x] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [x] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [x] Tags names and expected values should be similar to the other existing
   configurations.
1. [x] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [x] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [x] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
