### PR TITLE
Sqs workflow improvements

### DIFF
--- a/core/action.go
+++ b/core/action.go
@@ -82,3 +82,15 @@ func (ssi swapSpotInstance) run() {
 	spotInstanceID := *ssi.target.spotInstance.InstanceId
 	asg.replaceOnDemandInstanceWithSpot(spotInstanceID)
 }
+
+type sqsSendMessageOnInstanceLaunch struct {
+  target target
+}
+
+func (ssmoil sqsSendMessageOnInstanceLaunch) run() {
+        asg := ssmoil.target.asg
+	onDemandInstanceID := ssmoil.target.onDemandInstance.InstanceId
+	region := ssmoil.target.onDemandInstance.region
+	state := ssmoil.target.onDemandInstance.State.Name
+	region.sqsSendMessageOnInstanceLaunch(&asg.name, onDemandInstanceID, state, "cron-spot-instance-launch")
+}

--- a/core/region.go
+++ b/core/region.go
@@ -479,7 +479,7 @@ func (r *region) findEnabledASGByName(name string) *autoScalingGroup {
 	return nil
 }
 
-func (r *region) sqsSendMessageOnInstanceLaunch(asgName, instanceID, instanceState *string, instanceLifecycle, action string) error {
+func (r *region) sqsSendMessageOnInstanceLaunch(asgName, instanceID, instanceState *string, instanceLifecycle string) error {
 	inputJSON := "{\"version\":\"0\",\"id\":\"890abcde-f123-4567-890a-bcdef1234567\"," +
 		"\"detail-type\":\"EC2 Instance State-change Notification\",\"source\":\"aws.events\"," +
 		"\"account\":\"\",\"time\":\"" + time.Now().Format(time.RFC3339) + "\"," +
@@ -493,7 +493,7 @@ func (r *region) sqsSendMessageOnInstanceLaunch(asgName, instanceID, instanceSta
 	_, err := svc.SendMessage(
 		&sqs.SendMessageInput{
 			MessageBody:    &inputJSON,
-			MessageGroupId: aws.String(fmt.Sprintf("%s-%s-%s-%s", r.name, *asgName, instanceLifecycle, action)),
+			MessageGroupId: aws.String(fmt.Sprintf("%s-%s", r.name, *asgName)),
 			QueueUrl:       &r.conf.SQSQueueURL,
 		})
 
@@ -503,7 +503,7 @@ func (r *region) sqsSendMessageOnInstanceLaunch(asgName, instanceID, instanceSta
 		return err
 	}
 
-	log.Printf("%s Successfully sent %s instance %s launch event message"+
+	log.Printf("%s Successfully sent %s instance %s launch event message "+
 		"to the SQS Queue %s", r.name, instanceLifecycle, *instanceID, r.conf.SQSQueueURL)
 
 	return nil


### PR DESCRIPTION
guidelines:
* all replacement of ondemand with spot should be handled by sqs
messages and for the same ASG be sequentially
* spot life "outside asg" should be as short as possible
* should be possible to run without using SQSQueue, but ONLY wihout using
event based replacement too (cron only, so that cannot run at the same time two AS execution)
* only one method, swapWithGroupMember, is used to do ondeamnd
replacement

AS = Autospotting
CW = CloudWatch
SQS = Sqs Queue
CRON = Cron Schedule

1) CW ondemand event:
send message to SQS

2) SQS ondemand event:
launch spot replcament - wait for spot running - replace with
swapWithGroupMember

3) CW spot event:
do nothing (it's' needed to avoid intercepting spot launch of point 1)

4) CRON need to launch spot to replace ondemand:
if SQS is enabled we send message to SQS simulating an ondemand
  (ondemand launch)
  message
if SQS is disabled we directly launch spot replacement

5) CRON found spot to attach
if SQS is enabled we send message to SQS (spot launch)
if SQS is disabled we directly call swapWithGroupMember (by
  replaceOnDemandInstanceWithSpot)

6) SQS spot event:
replace with swapWithGroupMember

For point 4 sqs enabled, sending the message to the queue assure a
faster replacement, we do not need to wait for the next cron execution.

To be sure that all replacement for the same ASG (that can change ASG
max size and pause and resume services), are handled in a sequential
way, we use for SQS grouId ONLY the string {Region}-{AsgName}.

# Issue Type

<!--
Pick one below and delete the others.

Also feel free to delete these comments for brevity once they were fully
acknowledged.
-->

- Feature Pull Request
- Bugfix Pull Request
- Documentation Pull Request

## Summary

<!--
Describe the change, including rationale and design decisions, and use a brief
but descriptive PR title.

Please include "Fixes #nnn" here or in your commit message in order to
link to an issue in which you describe the addressed problem in more detail.

If you want to address more issues do it in different pull requests instead of a
single big one, it will speed up the review process considerably.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [ ] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
