### PR TITLE
dockerHub's URL structure is now case-sensitive.

### DIFF
--- a/CUSTOM_BUILDS.md
+++ b/CUSTOM_BUILDS.md
@@ -165,6 +165,6 @@ This also accepts all the AutoSpotting command-line arguments, including `-help`
 which explains all the available options.
 
 Pre-built Docker images for the latest builds are also available on Dockerhub at
-[AutoSpotting/AutoSpotting](https://hub.docker.com/r/autospotting/autospotting)
+[AutoSpotting/AutoSpotting](https://hub.docker.com/r/autospotting/autospotting/)
 
 [Back to the main Readme](./README.md)

--- a/CUSTOM_BUILDS.md
+++ b/CUSTOM_BUILDS.md
@@ -165,6 +165,6 @@ This also accepts all the AutoSpotting command-line arguments, including `-help`
 which explains all the available options.
 
 Pre-built Docker images for the latest builds are also available on Dockerhub at
-[AutoSpotting/AutoSpotting](https://hub.docker.com/r/AutoSpotting/AutoSpotting/)
+[AutoSpotting/AutoSpotting](https://hub.docker.com/r/autospotting/autospotting)
 
 [Back to the main Readme](./README.md)


### PR DESCRIPTION
# Issue Type

- Documentation Pull Request

## Summary
DockerHub now has case-sensitive URLs, thus the one in the docs was broken.
## Code contribution checklist

1. [ ✓] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
