### PR TITLE
Parameter to disable handling of instance rebalance recommendation events

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -117,6 +117,9 @@ type Config struct {
 
 	// DisableEventBasedInstanceReplacement forces execution in cron mode only
 	DisableEventBasedInstanceReplacement bool
+
+	// DisableInstanceRebalanceRecommendation disable the handling of Instance Rebalance Recommendation events.
+	DisableInstanceRebalanceRecommendation bool
 }
 
 // ParseConfig loads configuration from command line flags, environments variables, and config files.
@@ -252,6 +255,10 @@ func ParseConfig(conf *Config) {
 	flagSet.BoolVar(&conf.DisableEventBasedInstanceReplacement, "disable_event_based_instance_replacement", false,
 		"\n\tDisables the event based instance replacement, forcing the legacy cron mode.\n"+
 			"\tExample: ./AutoSpotting --disable_event_based_instance_replacement=true\n")
+
+	flagSet.BoolVar(&conf.DisableInstanceRebalanceRecommendation, "disable_instance_rebalance_recommendation", false,
+		"\n\tDisables handling of instance rebalance recommendation events.\n"+
+			"\tExample: ./AutoSpotting --disable_instance_rebalance_recommendation=true\n")
 
 	printVersion := flagSet.Bool("version", false, "Print version number and exit.\n")
 

--- a/core/main.go
+++ b/core/main.go
@@ -252,6 +252,10 @@ func (a *AutoSpotting) processEventInstance(eventType string, region string, ins
 		}
 		a.handleNewInstanceLaunch(region, *instanceID, *instanceState)
 	} else if eventType == SpotInstanceInterruptionWarningCode || eventType == InstanceRebalanceRecommendationCode {
+		if a.config.DisableInstanceRebalanceRecommendation {
+			log.Println("Handling of instance rebalance recommendation events is disabled, exiting...")
+			return nil
+		}
 		// If the event is for an Instance Spot Interruption/Rebalance
 		spotTermination := newSpotTermination(region)
 

--- a/core/main.go
+++ b/core/main.go
@@ -252,7 +252,7 @@ func (a *AutoSpotting) processEventInstance(eventType string, region string, ins
 		}
 		a.handleNewInstanceLaunch(region, *instanceID, *instanceState)
 	} else if eventType == SpotInstanceInterruptionWarningCode || eventType == InstanceRebalanceRecommendationCode {
-		if a.config.DisableInstanceRebalanceRecommendation {
+		if eventType == InstanceRebalanceRecommendationCode && a.config.DisableInstanceRebalanceRecommendation {
 			log.Println("Handling of instance rebalance recommendation events is disabled, exiting...")
 			return nil
 		}


### PR DESCRIPTION
# Issue Type

<!--
Pick one below and delete the others.

Also feel free to delete these comments for brevity once they were fully
acknowledged.
-->

- Feature Pull Request

## Summary
Added a parameter disable_instance_rebalance_recommendation (default to
false) to disable handling of instance rebalance recommendation events.

Often that events are false positive, the spot instance is not
terminated and even if now we do not remove anymore the tag:
launched-for-asg

can happen that, if we detach instance, the rate at which AutoSpotting
cron event terminate unused spot (usually 5min) is greater than the rate at which AWS send IRR events
(usually IRR events are related to the instance type and not
specifically to the instance itself).

What happen is:
AWS send IRR, we deatch spot instance (without decreasing ASG)
ASG launch a new ondemand
if ondemand is in different AZ of the previous detached instance, AS
 cannot use it, so launch a new spot
AWS send IRR for the new spot
and so on ....

AS every cron schedule terminate only one unused spot instance x ASG.
So terminatin rate is lower that new spot + deatch, and detached unused
spot can grow over time.

(whould be usefull to have the parameter overridable by ASG tags, but
for this we need greater change to the code, when we process IRR events
  we do not already know the ASG to which the instance belongs)
<!--
Describe the change, including rationale and design decisions, and use a brief
but descriptive PR title.

Please include "Fixes #nnn" here or in your commit message in order to
link to an issue in which you describe the addressed problem in more detail.

If you want to address more issues do it in different pull requests instead of a
single big one, it will speed up the review process considerably.

Code review process:

The issue should be tagged with 'review wanted' label before the checklist below
is satisfied from the perspective of the PR author and the code is ready to be
peer-reviewed.

The label should be set by a maintainer as soon as the review is requested on
Gitter and should only be cleared after the PR is merged.
-->

## Code contribution checklist

<!--
The code review should be largely a matter of going through this checklist.
-->

1. [X ] I hereby allow the Copyright holder the rights to distribute this piece of
   code under any software license.
1. [ ] The contribution fixes a single existing github issue, and it is linked
   to it.
1. [ ] The code is as simple as possible, readable and follows the idiomatic Go
  [guidelines](https://golang.org/doc/effective_go.html).
1. [ ] All new functionality is covered by automated test cases so the overall
  test coverage doesn't decrease.
1. [ ] No issues are reported when running `make full-test`.
1. [ ] Functionality not applicable to all users should be configurable.
1. [ ] Configurations should be exposed through Lambda function environment
   variables which are also passed as parameters to the
   [CloudFormation](https://github.com/cristim/autospotting/blob/master/cloudformation/stacks/AutoSpotting/template.yaml)
   and
   [Terraform](https://github.com/autospotting/terraform-aws-autospotting/main.tf)
   stacks defined as infrastructure code.
1. [ ] Global configurations set from the infrastructure stack level should also
   support per-group overrides using tags.
1. [ ] Tags names and expected values should be similar to the other existing
   configurations.
1. [ ] Both global and tag-based configuration mechanisms should be tested and
  proven to work using log output from various test runs.
1. [ ] The logs should be kept as clean as possible (use log levels as
  appropriate) and formatted consistently to the existing log output.
1. [ ] The documentation is updated to cover the new behavior, as well as the
   new configuration options for both stack parameters and tag overrides.
1. [ ] A code reviewer reproduced the problem and can confirm the code
  contribution actually resolves it.
